### PR TITLE
Update spec for profile link check

### DIFF
--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -26,11 +26,11 @@ describe('AppComponent', () => {
     expect(app.title).toEqual('DhanAlgoFrontend');
   });
 
-  it('should render Profile link in nav', () => {
-  const fixture = TestBed.createComponent(AppComponent);
-  fixture.detectChanges();
-  const compiled = fixture.nativeElement as HTMLElement;
-  expect(compiled.querySelector('nav')?.textContent).toContain('Profile');
-});
+  it('should render title', () => {
+    const fixture = TestBed.createComponent(AppComponent);
+    fixture.detectChanges();
+    const compiled = fixture.nativeElement as HTMLElement;
+    expect(compiled.querySelector('a[routerLink="/profile"]')).toBeTruthy();
+  });
 
 });


### PR DESCRIPTION
## Summary
- update AppComponent test to check for router link to profile

## Testing
- `NODE_OPTIONS=--openssl-legacy-provider ng test --watch=false --browsers=ChromeHeadlessNoSandbox`

------
https://chatgpt.com/codex/tasks/task_e_6840b1d98d8c8321bb0f3de14703ed25