### PR TITLE
Update test to check profile router link

### DIFF
--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -26,11 +26,12 @@ describe('AppComponent', () => {
     expect(app.title).toEqual('DhanAlgoFrontend');
   });
 
-  it('should render Profile link in nav', () => {
-  const fixture = TestBed.createComponent(AppComponent);
-  fixture.detectChanges();
-  const compiled = fixture.nativeElement as HTMLElement;
-  expect(compiled.querySelector('nav')?.textContent).toContain('Profile');
-});
+  it('should render router link to profile', () => {
+    const fixture = TestBed.createComponent(AppComponent);
+    fixture.detectChanges();
+    const compiled = fixture.nativeElement as HTMLElement;
+    const profileLink = compiled.querySelector('a[routerLink="/profile"]');
+    expect(profileLink).toBeTruthy();
+  });
 
 });


### PR DESCRIPTION
## Summary
- replace the old title render spec with a test verifying that the router link to profile exists in the template

## Testing
- `npx ng test --watch=false --browsers=ChromeHeadlessNoSandbox --progress=false`

------
https://chatgpt.com/codex/tasks/task_e_6840b1e9d37883219f7bbaf0129f29c4