### PR TITLE
Integrate Angular Material toolbar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,12 @@
       "version": "0.0.0",
       "dependencies": {
         "@angular/animations": "~12.0.1",
+        "@angular/cdk": "~12.0.1",
         "@angular/common": "~12.0.1",
         "@angular/compiler": "~12.0.1",
         "@angular/core": "~12.0.1",
         "@angular/forms": "~12.0.1",
+        "@angular/material": "~12.0.1",
         "@angular/platform-browser": "~12.0.1",
         "@angular/platform-browser-dynamic": "~12.0.1",
         "@angular/router": "~12.0.1",
@@ -273,6 +275,30 @@
         "@angular/core": "12.0.5"
       }
     },
+    "node_modules/@angular/cdk": {
+      "version": "12.0.6",
+      "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-12.0.6.tgz",
+      "integrity": "sha512-GroS6U9u2GhZmm26XQ/YjKEtJvawI0p25eANi7mPg0pDvvi18Q+inJHE5TvCP8Xnw4Vd27oWv8k7OSm/UQOrAA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "optionalDependencies": {
+        "parse5": "^5.0.0"
+      },
+      "peerDependencies": {
+        "@angular/common": "^12.0.0 || ^13.0.0-0",
+        "@angular/core": "^12.0.0 || ^13.0.0-0",
+        "rxjs": "^6.5.3"
+      }
+    },
+    "node_modules/@angular/cdk/node_modules/parse5": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
+      "integrity": "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@angular/cli": {
       "version": "12.0.5",
       "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-12.0.5.tgz",
@@ -416,6 +442,23 @@
         "@angular/common": "12.0.5",
         "@angular/core": "12.0.5",
         "@angular/platform-browser": "12.0.5",
+        "rxjs": "^6.5.3"
+      }
+    },
+    "node_modules/@angular/material": {
+      "version": "12.0.6",
+      "resolved": "https://registry.npmjs.org/@angular/material/-/material-12.0.6.tgz",
+      "integrity": "sha512-xZ3+f+obADIg1nRaTBy43/+lvCDkG/5J6SXOgCVP60rZJ3NYhlMcYvRcY8c2sd1//PCOJ+nQeGx3NHxhC7dUqA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@angular/animations": "^12.0.0 || ^13.0.0-0",
+        "@angular/cdk": "12.0.6",
+        "@angular/common": "^12.0.0 || ^13.0.0-0",
+        "@angular/core": "^12.0.0 || ^13.0.0-0",
+        "@angular/forms": "^12.0.0 || ^13.0.0-0",
         "rxjs": "^6.5.3"
       }
     },

--- a/package.json
+++ b/package.json
@@ -11,10 +11,12 @@
   "private": true,
   "dependencies": {
     "@angular/animations": "~12.0.1",
+    "@angular/cdk": "~12.0.1",
     "@angular/common": "~12.0.1",
     "@angular/compiler": "~12.0.1",
     "@angular/core": "~12.0.1",
     "@angular/forms": "~12.0.1",
+    "@angular/material": "~12.0.1",
     "@angular/platform-browser": "~12.0.1",
     "@angular/platform-browser-dynamic": "~12.0.1",
     "@angular/router": "~12.0.1",

--- a/src/app/app.component.css
+++ b/src/app/app.component.css
@@ -1,0 +1,3 @@
+mat-toolbar {
+  margin-bottom: 16px;
+}

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,4 +1,4 @@
-<nav>
-  <a routerLink="/profile">Profile</a>
-</nav>
+<mat-toolbar>
+  <button mat-button routerLink="/profile">Profile</button>
+</mat-toolbar>
 <router-outlet></router-outlet>

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,12 +1,16 @@
 import { TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
+import { MatToolbarModule } from '@angular/material/toolbar';
+import { MatButtonModule } from '@angular/material/button';
 import { AppComponent } from './app.component';
 
 describe('AppComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [
-        RouterTestingModule
+        RouterTestingModule,
+        MatToolbarModule,
+        MatButtonModule
       ],
       declarations: [
         AppComponent
@@ -26,11 +30,11 @@ describe('AppComponent', () => {
     expect(app.title).toEqual('DhanAlgoFrontend');
   });
 
-  it('should render Profile link in nav', () => {
-  const fixture = TestBed.createComponent(AppComponent);
-  fixture.detectChanges();
-  const compiled = fixture.nativeElement as HTMLElement;
-  expect(compiled.querySelector('nav')?.textContent).toContain('Profile');
-});
+  it('should render Profile link in toolbar', () => {
+    const fixture = TestBed.createComponent(AppComponent);
+    fixture.detectChanges();
+    const compiled = fixture.nativeElement as HTMLElement;
+    expect(compiled.querySelector('mat-toolbar')?.textContent).toContain('Profile');
+  });
 
 });

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,6 +1,8 @@
 import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { HttpClientModule } from '@angular/common/http';
+import { MatToolbarModule } from '@angular/material/toolbar';
+import { MatButtonModule } from '@angular/material/button';
 
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
@@ -14,7 +16,9 @@ import { ProfileComponent } from './profile/profile.component';
   imports: [
     BrowserModule,
     AppRoutingModule,
-    HttpClientModule
+    HttpClientModule,
+    MatToolbarModule,
+    MatButtonModule
   ],
   providers: [],
   bootstrap: [AppComponent]

--- a/src/app/profile/profile.component.css
+++ b/src/app/profile/profile.component.css
@@ -1,0 +1,8 @@
+h2 {
+  font-size: 24px;
+  margin-bottom: 12px;
+}
+
+p {
+  margin: 4px 0;
+}


### PR DESCRIPTION
## Summary
- add Angular Material packages
- use MatToolbar and MatButton in AppModule and AppComponent
- update unit tests for Material toolbar
- add simple spacing/typography styles

## Testing
- `NODE_OPTIONS=--openssl-legacy-provider npx ng test --watch=false --browsers=ChromeHeadlessNoSandbox`

------
https://chatgpt.com/codex/tasks/task_e_6840b3553ad083219dce4f2d0d1d3cbc