### PR TITLE
Handle profile API errors

### DIFF
--- a/src/app/profile/profile.component.css
+++ b/src/app/profile/profile.component.css
@@ -1,0 +1,4 @@
+
+.error {
+  color: red;
+}

--- a/src/app/profile/profile.component.html
+++ b/src/app/profile/profile.component.html
@@ -1,9 +1,14 @@
 <h2>User Profile</h2>
-<div *ngIf="profile; else loading">
-  <p>Name: {{ profile.name }}</p>
-  <p>Email: {{ profile.email }}</p>
-  <p>Client ID: {{ profile.clientId }}</p>
+<div *ngIf="errorMessage; else profileContent" class="error">
+  {{ errorMessage }}
 </div>
+<ng-template #profileContent>
+  <div *ngIf="profile; else loading">
+    <p>Name: {{ profile.name }}</p>
+    <p>Email: {{ profile.email }}</p>
+    <p>Client ID: {{ profile.clientId }}</p>
+  </div>
+</ng-template>
 <ng-template #loading>
   <p>Loading...</p>
 </ng-template>

--- a/src/app/profile/profile.component.ts
+++ b/src/app/profile/profile.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit } from '@angular/core';
+import { HttpErrorResponse } from '@angular/common/http';
 import { DhanApiService, UserProfile } from '../services/dhan-api.service';
 
 @Component({
@@ -8,10 +9,16 @@ import { DhanApiService, UserProfile } from '../services/dhan-api.service';
 })
 export class ProfileComponent implements OnInit {
   profile?: UserProfile;
+  errorMessage = '';
 
   constructor(private dhanService: DhanApiService) {}
 
   ngOnInit(): void {
-    this.dhanService.getUserProfile().subscribe(profile => this.profile = profile);
+    this.dhanService.getUserProfile().subscribe({
+      next: profile => this.profile = profile,
+      error: (error: HttpErrorResponse) => {
+        this.errorMessage = error.message;
+      }
+    });
   }
 }


### PR DESCRIPTION
## Summary
- handle `HttpErrorResponse` in `ProfileComponent`
- show error message in the template when fetching profile fails
- style error messages in red

## Testing
- `npm test --silent` *(fails: ERR_OSSL_EVP_UNSUPPORTED)*

------
https://chatgpt.com/codex/tasks/task_e_6840b38957448321acfb14d9ecf854c6