### PR TITLE
Add tests for DhanApiService and ProfileComponent

### DIFF
--- a/src/app/profile/profile.component.spec.ts
+++ b/src/app/profile/profile.component.spec.ts
@@ -1,0 +1,45 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { ProfileComponent } from './profile.component';
+import { DhanApiService } from '../services/dhan-api.service';
+import { environment } from '../../environments/environment';
+
+describe('ProfileComponent', () => {
+  let component: ProfileComponent;
+  let fixture: ComponentFixture<ProfileComponent>;
+  let httpMock: HttpTestingController;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ProfileComponent],
+      imports: [HttpClientTestingModule],
+      providers: [DhanApiService]
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ProfileComponent);
+    component = fixture.componentInstance;
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('should display user data when service returns a profile', () => {
+    const mockProfile = { name: 'John Doe', email: 'john@example.com', clientId: '123' };
+
+    fixture.detectChanges();
+
+    const req = httpMock.expectOne(`${environment.apiUrl}/TestDhan/profile`);
+    req.flush(mockProfile);
+
+    fixture.detectChanges();
+    const compiled = fixture.nativeElement as HTMLElement;
+
+    expect(compiled.textContent).toContain('Name: John Doe');
+    expect(compiled.textContent).toContain('Email: john@example.com');
+    expect(compiled.textContent).toContain('Client ID: 123');
+  });
+});

--- a/src/app/services/dhan-api.service.spec.ts
+++ b/src/app/services/dhan-api.service.spec.ts
@@ -1,0 +1,31 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { DhanApiService } from './dhan-api.service';
+import { environment } from '../../environments/environment';
+
+describe('DhanApiService', () => {
+  let service: DhanApiService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [DhanApiService]
+    });
+
+    service = TestBed.inject(DhanApiService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('should call /TestDhan/profile with the correct base URL', () => {
+    service.getUserProfile().subscribe();
+
+    const req = httpMock.expectOne(`${environment.apiUrl}/TestDhan/profile`);
+    expect(req.request.method).toBe('GET');
+    req.flush({});
+  });
+});


### PR DESCRIPTION
## Summary
- add HttpClient tests for `DhanApiService`
- verify that `ProfileComponent` renders profile data

## Testing
- `NODE_OPTIONS=--openssl-legacy-provider npx ng test --watch=false --browsers=ChromeHeadlessNoSandbox --no-progress`

------
https://chatgpt.com/codex/tasks/task_e_6840b37ebb588321a7dcd7ad72eca408