### PR TITLE
Fix spec for profile link

### DIFF
--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -26,11 +26,11 @@ describe('AppComponent', () => {
     expect(app.title).toEqual('DhanAlgoFrontend');
   });
 
-  it('should render Profile link in nav', () => {
-  const fixture = TestBed.createComponent(AppComponent);
-  fixture.detectChanges();
-  const compiled = fixture.nativeElement as HTMLElement;
-  expect(compiled.querySelector('nav')?.textContent).toContain('Profile');
-});
+  it('should render profile link', () => {
+    const fixture = TestBed.createComponent(AppComponent);
+    fixture.detectChanges();
+    const compiled = fixture.nativeElement as HTMLElement;
+    expect(compiled.querySelector('a[routerLink="/profile"]')).not.toBeNull();
+  });
 
 });


### PR DESCRIPTION
## Summary
- update `AppComponent` spec to check for `<a routerLink="/profile">`

## Testing
- `npx ng test --watch=false`

------
https://chatgpt.com/codex/tasks/task_e_6840b3adf9648321a532fe6de8115a8e