### PR TITLE
Fix build and pages artifact paths

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -36,8 +36,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          # Upload entire repository
-          path: '.'
+          path: 'dist/DhanAlgoFrontend'
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4

--- a/.github/workflows/webpack.yml
+++ b/.github/workflows/webpack.yml
@@ -25,4 +25,4 @@ jobs:
     - name: Build
       run: |
         npm install
-        npx webpack
+        npm run build


### PR DESCRIPTION
## Summary
- use `npm run build` in webpack workflow
- deploy built assets from `dist/DhanAlgoFrontend` to GitHub Pages

## Testing
- `npm test -- --watch=false` *(fails: ERR_OSSL_EVP_UNSUPPORTED)*

------
https://chatgpt.com/codex/tasks/task_e_684147894b1083218c36510ad0288708