### PR TITLE
Update profile link tests

### DIFF
--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -30,18 +30,18 @@ describe('AppComponent', () => {
     expect(app.title).toEqual('DhanAlgoFrontend');
   });
 
-  it('should render a link to the profile page', () => {
+  it('should render a button to the profile page', () => {
     const fixture = TestBed.createComponent(AppComponent);
     fixture.detectChanges();
     const compiled = fixture.nativeElement as HTMLElement;
-    expect(compiled.querySelector('a[routerLink="/profile"]')).not.toBeNull();
+    expect(compiled.querySelector('button[routerLink="/profile"]')).not.toBeNull();
   });
 
-  it('should render profile link with routerLink="/profile"', () => {
+  it('should render profile button with routerLink="/profile"', () => {
     const fixture = TestBed.createComponent(AppComponent);
     fixture.detectChanges();
     const compiled = fixture.nativeElement as HTMLElement;
-    const link = compiled.querySelector('a[routerLink="/profile"]');
-    expect(link).not.toBeNull();
+    const button = compiled.querySelector('button[routerLink="/profile"]');
+    expect(button).not.toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- update spec queries to look for profile button

## Testing
- `NODE_OPTIONS=--openssl-legacy-provider npm test -- --watch=false` *(fails: AppComponent should render profile button with routerLink="/profile")*

------
https://chatgpt.com/codex/tasks/task_e_68414036c2e483218afa50334c9d8f6d