### PR TITLE
Improve profile view layout

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -3,6 +3,7 @@ import { BrowserModule } from '@angular/platform-browser';
 import { HttpClientModule } from '@angular/common/http';
 import { MatToolbarModule } from '@angular/material/toolbar';
 import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
 
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
@@ -18,7 +19,8 @@ import { ProfileComponent } from './profile/profile.component';
     AppRoutingModule,
     HttpClientModule,
     MatToolbarModule,
-    MatButtonModule
+    MatButtonModule,
+    MatCardModule
   ],
   providers: [],
   bootstrap: [AppComponent]

--- a/src/app/profile/profile.component.css
+++ b/src/app/profile/profile.component.css
@@ -1,14 +1,21 @@
 
-h2 {
-  font-size: 24px;
-  margin-bottom: 12px;
+.profile-card {
+  margin: 16px auto;
+  max-width: 400px;
 }
 
-p {
-  margin: 4px 0;
+.field {
+  margin-bottom: 8px;
+  font-size: 14px;
 }
 
-.error {
-  color: red;
+.label {
+  font-weight: 600;
+  margin-right: 4px;
+}
 
+.error-message {
+  color: #f44336;
+  margin: 16px;
+  font-weight: 500;
 }

--- a/src/app/profile/profile.component.html
+++ b/src/app/profile/profile.component.html
@@ -1,14 +1,21 @@
-<h2>User Profile</h2>
-<div *ngIf="errorMessage; else profileContent" class="error">
-  {{ errorMessage }}
-</div>
-<ng-template #profileContent>
-  <div *ngIf="profile; else loading">
-    <p>Name: {{ profile.name }}</p>
-    <p>Email: {{ profile.email }}</p>
-    <p>Client ID: {{ profile.clientId }}</p>
-  </div>
-</ng-template>
-<ng-template #loading>
-  <p>Loading...</p>
+<ng-container *ngIf="errorMessage; else profileCard">
+  <div class="error-message">{{ errorMessage }}</div>
+</ng-container>
+
+<ng-template #profileCard>
+  <mat-card class="profile-card">
+    <mat-card-header>
+      <mat-card-title>User Profile</mat-card-title>
+    </mat-card-header>
+    <mat-card-content>
+      <div *ngIf="profile; else loading">
+        <p class="field"><span class="label">Name:</span> {{ profile.name }}</p>
+        <p class="field"><span class="label">Email:</span> {{ profile.email }}</p>
+        <p class="field"><span class="label">Client ID:</span> {{ profile.clientId }}</p>
+      </div>
+      <ng-template #loading>
+        <p>Loading...</p>
+      </ng-template>
+    </mat-card-content>
+  </mat-card>
 </ng-template>


### PR DESCRIPTION
## Summary
- show profile fields in Material card
- style card spacing, typography and error message
- import `MatCardModule` for card component

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless --no-progress` *(fails: No binary for ChromeHeadless)*

------
https://chatgpt.com/codex/tasks/task_e_684164cf5a9083219f953aa2f942c29d