### PR TITLE
Add profile component and API service tests

### DIFF
--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -30,12 +30,6 @@ describe('AppComponent', () => {
     expect(app.title).toEqual('DhanAlgoFrontend');
   });
 
-  it('should render a button to the profile page', () => {
-    const fixture = TestBed.createComponent(AppComponent);
-    fixture.detectChanges();
-    const compiled = fixture.nativeElement as HTMLElement;
-    expect(compiled.querySelector('button[routerLink="/profile"]')).not.toBeNull();
-  });
 
   it('should render profile button with routerLink="/profile"', () => {
     const fixture = TestBed.createComponent(AppComponent);

--- a/src/app/profile/profile.component.spec.ts
+++ b/src/app/profile/profile.component.spec.ts
@@ -1,0 +1,45 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpErrorResponse } from '@angular/common/http';
+import { of, throwError } from 'rxjs';
+
+import { ProfileComponent } from './profile.component';
+import { DhanApiService, UserProfile } from '../services/dhan-api.service';
+
+describe('ProfileComponent', () => {
+  let component: ProfileComponent;
+  let fixture: ComponentFixture<ProfileComponent>;
+  let dhanService: jasmine.SpyObj<DhanApiService>;
+
+  beforeEach(async () => {
+    dhanService = jasmine.createSpyObj('DhanApiService', ['getUserProfile']);
+
+    await TestBed.configureTestingModule({
+      declarations: [ProfileComponent],
+      providers: [{ provide: DhanApiService, useValue: dhanService }]
+    }).compileComponents();
+  });
+
+  it('should load profile data on init', () => {
+    const mockProfile: UserProfile = { name: 'Test', email: 'test@example.com', clientId: '1' };
+    dhanService.getUserProfile.and.returnValue(of(mockProfile));
+
+    fixture = TestBed.createComponent(ProfileComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+
+    expect(component.profile).toEqual(mockProfile);
+    expect(component.errorMessage).toBe('');
+  });
+
+  it('should set errorMessage when service fails', () => {
+    const error = new HttpErrorResponse({ status: 500, statusText: 'Server Error' });
+    dhanService.getUserProfile.and.returnValue(throwError(() => error));
+
+    fixture = TestBed.createComponent(ProfileComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+
+    expect(component.profile).toBeUndefined();
+    expect(component.errorMessage).toContain('Server Error');
+  });
+});

--- a/src/app/services/dhan-api.service.spec.ts
+++ b/src/app/services/dhan-api.service.spec.ts
@@ -1,0 +1,51 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+
+import { DhanApiService, UserProfile } from './dhan-api.service';
+import { environment } from '../../environments/environment';
+
+describe('DhanApiService', () => {
+  let service: DhanApiService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [DhanApiService]
+    });
+    service = TestBed.inject(DhanApiService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('should fetch user profile', () => {
+    const mockProfile: UserProfile = { name: 'Test', email: 'test@example.com', clientId: '1' };
+
+    service.getUserProfile().subscribe(profile => {
+      expect(profile).toEqual(mockProfile);
+    });
+
+    const req = httpMock.expectOne(`${environment.apiUrl}/TestDhan/profile`);
+    expect(req.request.method).toBe('GET');
+    req.flush(mockProfile);
+  });
+
+  it('should propagate error when request fails', () => {
+    const status = 500;
+    const statusText = 'Server Error';
+
+    service.getUserProfile().subscribe({
+      next: () => fail('should have errored'),
+      error: error => {
+        expect(error.status).toBe(status);
+        expect(error.statusText).toBe(statusText);
+      }
+    });
+
+    const req = httpMock.expectOne(`${environment.apiUrl}/TestDhan/profile`);
+    req.flush('Error', { status, statusText });
+  });
+});


### PR DESCRIPTION
## Summary
- remove duplicate profile button test in AppComponent spec
- add ProfileComponent spec for profile loading and error handling
- add DhanApiService spec for success and error cases

## Testing
- `npx ng test --watch=false --browsers=ChromeHeadlessNoSandbox --code-coverage=false` *(fails: No binary for ChromeHeadless)*

------
https://chatgpt.com/codex/tasks/task_e_684164d26490832183a60a94174af2ff