### PR TITLE
Update profile UI and add tests

### DIFF
--- a/src/app/profile/profile.component.html
+++ b/src/app/profile/profile.component.html
@@ -1,0 +1,8 @@
+<mat-card class="profile-card">
+  <div *ngIf="profile">
+    <div class="field"><span class="label">Name:</span>{{ profile.name }}</div>
+    <div class="field"><span class="label">Email:</span>{{ profile.email }}</div>
+    <div class="field"><span class="label">Client ID:</span>{{ profile.clientId }}</div>
+  </div>
+  <div *ngIf="errorMessage" class="error-message">{{ errorMessage }}</div>
+</mat-card>

--- a/src/app/profile/profile.component.spec.ts
+++ b/src/app/profile/profile.component.spec.ts
@@ -1,0 +1,68 @@
+import { ComponentFixture, TestBed, fakeAsync, tick, waitForAsync } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { of, throwError } from 'rxjs';
+import { HttpErrorResponse } from '@angular/common/http';
+
+import { ProfileComponent } from './profile.component';
+import { DhanApiService, UserProfile } from '../services/dhan-api.service';
+import { MatCardModule } from '@angular/material/card';
+
+describe('ProfileComponent', () => {
+  let component: ProfileComponent;
+  let fixture: ComponentFixture<ProfileComponent>;
+  let dhanService: jasmine.SpyObj<DhanApiService>;
+
+  beforeEach(async () => {
+    const dhanSpy = jasmine.createSpyObj('DhanApiService', ['getUserProfile']);
+
+    await TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule, MatCardModule],
+      declarations: [ProfileComponent],
+      providers: [{ provide: DhanApiService, useValue: dhanSpy }]
+    }).compileComponents();
+
+    dhanService = TestBed.inject(DhanApiService) as jasmine.SpyObj<DhanApiService>;
+  });
+
+  function createComponent() {
+    fixture = TestBed.createComponent(ProfileComponent);
+    component = fixture.componentInstance;
+  }
+
+  it('should render profile data from the service', () => {
+    const mockProfile: UserProfile = { name: 'Jane', email: 'jane@example.com', clientId: 'CID123' };
+    dhanService.getUserProfile.and.returnValue(of(mockProfile));
+
+    createComponent();
+    fixture.detectChanges();
+
+    const compiled = fixture.nativeElement as HTMLElement;
+    const fields = compiled.querySelectorAll('.field');
+    expect(fields.length).toBe(3);
+    expect(fields[0].textContent).toContain('Jane');
+    expect(fields[1].textContent).toContain('jane@example.com');
+    expect(fields[2].textContent).toContain('CID123');
+  });
+
+  it('should display an error message on service error', waitForAsync(() => {
+    const error = new HttpErrorResponse({ status: 500, statusText: 'Server Error' });
+    dhanService.getUserProfile.and.returnValue(throwError(error));
+
+    createComponent();
+    fixture.detectChanges();
+
+    fixture.whenStable().then(() => {
+      fixture.detectChanges();
+
+      expect(dhanService.getUserProfile).toHaveBeenCalled();
+
+      const compiled = fixture.nativeElement as HTMLElement;
+      const errorEl = compiled.querySelector('.error-message');
+      expect(component.errorMessage).toContain('Server Error');
+      expect(errorEl).not.toBeNull();
+      if (errorEl) {
+        expect(errorEl.textContent).toContain('Server Error');
+      }
+    });
+  }));
+});


### PR DESCRIPTION
## Summary
- build profile details UI using Angular Material
- add unit tests for ProfileComponent

## Testing
- `npm test --silent -- --watch=false`

------
https://chatgpt.com/codex/tasks/task_e_68418792ecc48321ab43de5c199a4138