### PR TITLE
Add dashboard view with trading service

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -1,10 +1,12 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 import { ProfileComponent } from './profile/profile.component';
+import { DashboardComponent } from './dashboard/dashboard.component';
 
 const routes: Routes = [
   { path: '', redirectTo: 'profile', pathMatch: 'full' },
-  { path: 'profile', component: ProfileComponent }
+  { path: 'profile', component: ProfileComponent },
+  { path: 'dashboard', component: DashboardComponent }
 ];
 
 @NgModule({

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,5 +1,6 @@
 <mat-toolbar>
   <a mat-button routerLink="/profile">Profile</a>
+  <a mat-button routerLink="/dashboard">Dashboard</a>
 </mat-toolbar>
 <div class="container mt-3">
   <router-outlet></router-outlet>

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -4,15 +4,18 @@ import { HttpClientModule } from '@angular/common/http';
 import { MatToolbarModule } from '@angular/material/toolbar';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
+import { MatTableModule } from '@angular/material/table';
 
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
 import { ProfileComponent } from './profile/profile.component';
+import { DashboardComponent } from './dashboard/dashboard.component';
 
 @NgModule({
   declarations: [
     AppComponent,
-    ProfileComponent
+    ProfileComponent,
+    DashboardComponent
   ],
   imports: [
     BrowserModule,
@@ -20,7 +23,8 @@ import { ProfileComponent } from './profile/profile.component';
     HttpClientModule,
     MatToolbarModule,
     MatButtonModule,
-    MatCardModule
+    MatCardModule,
+    MatTableModule
   ],
   providers: [],
   bootstrap: [AppComponent]

--- a/src/app/dashboard/dashboard.component.css
+++ b/src/app/dashboard/dashboard.component.css
@@ -1,0 +1,15 @@
+.pnl-card {
+  margin-bottom: 16px;
+}
+
+.pnl-title {
+  font-weight: 600;
+}
+
+.pnl-value {
+  font-size: 24px;
+}
+
+.full-width {
+  width: 100%;
+}

--- a/src/app/dashboard/dashboard.component.html
+++ b/src/app/dashboard/dashboard.component.html
@@ -1,0 +1,36 @@
+<mat-card class="pnl-card">
+  <div class="pnl-title">Current Live P&amp;L</div>
+  <div class="pnl-value">{{ pnl$ | async }}</div>
+</mat-card>
+
+<mat-card>
+  <table mat-table [dataSource]="positions$ | async" class="mat-elevation-z8 full-width">
+    <ng-container matColumnDef="symbol">
+      <th mat-header-cell *matHeaderCellDef>Symbol</th>
+      <td mat-cell *matCellDef="let pos">{{ pos.symbol }}</td>
+    </ng-container>
+
+    <ng-container matColumnDef="quantity">
+      <th mat-header-cell *matHeaderCellDef>Qty</th>
+      <td mat-cell *matCellDef="let pos">{{ pos.quantity }}</td>
+    </ng-container>
+
+    <ng-container matColumnDef="entryPrice">
+      <th mat-header-cell *matHeaderCellDef>Entry Price</th>
+      <td mat-cell *matCellDef="let pos">{{ pos.entryPrice }}</td>
+    </ng-container>
+
+    <ng-container matColumnDef="currentPrice">
+      <th mat-header-cell *matHeaderCellDef>Current Price</th>
+      <td mat-cell *matCellDef="let pos">{{ pos.currentPrice }}</td>
+    </ng-container>
+
+    <ng-container matColumnDef="mtm">
+      <th mat-header-cell *matHeaderCellDef>MTM</th>
+      <td mat-cell *matCellDef="let pos">{{ pos.mtm }}</td>
+    </ng-container>
+
+    <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+    <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
+  </table>
+</mat-card>

--- a/src/app/dashboard/dashboard.component.spec.ts
+++ b/src/app/dashboard/dashboard.component.spec.ts
@@ -1,0 +1,50 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { of } from 'rxjs';
+import { MatCardModule } from '@angular/material/card';
+import { MatTableModule } from '@angular/material/table';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+import { DashboardComponent } from './dashboard.component';
+import { TradingService, Position } from '../services/trading.service';
+
+describe('DashboardComponent', () => {
+  let component: DashboardComponent;
+  let fixture: ComponentFixture<DashboardComponent>;
+  let tradingService: jasmine.SpyObj<TradingService>;
+
+  beforeEach(async () => {
+    const serviceSpy = jasmine.createSpyObj('TradingService', ['getCurrentPnl', 'getOpenPositions']);
+
+    await TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule, MatCardModule, MatTableModule, NoopAnimationsModule],
+      declarations: [DashboardComponent],
+      providers: [{ provide: TradingService, useValue: serviceSpy }]
+    }).compileComponents();
+
+    tradingService = TestBed.inject(TradingService) as jasmine.SpyObj<TradingService>;
+  });
+
+  function createComponent() {
+    fixture = TestBed.createComponent(DashboardComponent);
+    component = fixture.componentInstance;
+  }
+
+  it('should display pnl and positions from the service', () => {
+    const mockPnl = 2500;
+    const mockPositions: Position[] = [
+      { symbol: 'AAPL', quantity: 1, entryPrice: 100, currentPrice: 110, mtm: 10 }
+    ];
+    tradingService.getCurrentPnl.and.returnValue(of(mockPnl));
+    tradingService.getOpenPositions.and.returnValue(of(mockPositions));
+
+    createComponent();
+    fixture.detectChanges();
+    fixture.detectChanges();
+
+    const compiled = fixture.nativeElement as HTMLElement;
+    expect(compiled.querySelector('.pnl-value')?.textContent).toContain(mockPnl.toString());
+    const rows = compiled.querySelectorAll('tr.mat-row');
+    expect(rows.length).toBe(1);
+  });
+});

--- a/src/app/dashboard/dashboard.component.ts
+++ b/src/app/dashboard/dashboard.component.ts
@@ -1,0 +1,22 @@
+import { Component, OnInit } from '@angular/core';
+import { Observable } from 'rxjs';
+import { TradingService, Position } from '../services/trading.service';
+
+@Component({
+  selector: 'app-dashboard',
+  templateUrl: './dashboard.component.html',
+  styleUrls: ['./dashboard.component.css']
+})
+export class DashboardComponent implements OnInit {
+  pnl$!: Observable<number>;
+  positions$!: Observable<Position[]>;
+
+  displayedColumns = ['symbol', 'quantity', 'entryPrice', 'currentPrice', 'mtm'];
+
+  constructor(private tradingService: TradingService) {}
+
+  ngOnInit(): void {
+    this.pnl$ = this.tradingService.getCurrentPnl();
+    this.positions$ = this.tradingService.getOpenPositions();
+  }
+}

--- a/src/app/services/trading.service.spec.ts
+++ b/src/app/services/trading.service.spec.ts
@@ -1,0 +1,44 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { TradingService, Position } from './trading.service';
+import { environment } from '../../environments/environment';
+
+describe('TradingService', () => {
+  let service: TradingService;
+  let http: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule]
+    });
+    service = TestBed.inject(TradingService);
+    http = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    http.verify();
+  });
+
+  it('should fetch current pnl', () => {
+    let response: number | undefined;
+    service.getCurrentPnl().subscribe(pnl => (response = pnl));
+
+    const req = http.expectOne(`${environment.apiUrl}/positions/pnl`);
+    expect(req.request.method).toBe('GET');
+    req.flush(42);
+    expect(response).toBe(42);
+  });
+
+  it('should fetch open positions', () => {
+    const mockPositions: Position[] = [
+      { symbol: 'AAPL', quantity: 1, entryPrice: 1, currentPrice: 2, mtm: 1 }
+    ];
+    let response: Position[] | undefined;
+    service.getOpenPositions().subscribe(pos => (response = pos));
+
+    const req = http.expectOne(`${environment.apiUrl}/positions`);
+    expect(req.request.method).toBe('GET');
+    req.flush(mockPositions);
+    expect(response).toEqual(mockPositions);
+  });
+});

--- a/src/app/services/trading.service.ts
+++ b/src/app/services/trading.service.ts
@@ -1,0 +1,29 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from '../../environments/environment';
+
+export interface Position {
+  symbol: string;
+  quantity: number;
+  entryPrice: number;
+  currentPrice: number;
+  mtm: number;
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class TradingService {
+  private baseUrl = environment.apiUrl;
+
+  constructor(private http: HttpClient) {}
+
+  getCurrentPnl(): Observable<number> {
+    return this.http.get<number>(`${this.baseUrl}/positions/pnl`);
+  }
+
+  getOpenPositions(): Observable<Position[]> {
+    return this.http.get<Position[]>(`${this.baseUrl}/positions`);
+  }
+}


### PR DESCRIPTION
## Summary
- add reusable TradingService for P&L and positions API
- show P&L and open positions in new DashboardComponent
- register the dashboard route and navigation link
- add unit tests for the service and component

## Testing
- `npm test -- --watch=false`

------
https://chatgpt.com/codex/tasks/task_e_68418afa354c8321a9d1a9f502231a96