### PR TITLE
Fix duplicate CHROME_BIN assignment in karma.conf.js

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,8 +1,5 @@
 // Karma configuration file, see link for more information
 // https://karma-runner.github.io/1.0/config/configuration-file.html
-// Use Puppeteer to provide a Chromium binary for headless tests
-process.env.CHROME_BIN = require('puppeteer').executablePath();
-
 // Use Puppeteer-provided Chromium for headless tests
 process.env.CHROME_BIN = require('puppeteer').executablePath();
 


### PR DESCRIPTION
## Summary
- remove duplicate CHROME_BIN assignment so puppeteer path is set once at top

## Testing
- `npm test` *(fails: Disconnected Client disconnected from CONNECTED state)*

------
https://chatgpt.com/codex/tasks/task_e_684191e8712483218d1543933fd7c65a