### PR TITLE
Update README for Node ≥17 note

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ You can change these values in
 ## Prerequisites
 
 - Node.js **12.14** or newer (Node 14 is recommended)
+- If using Node **17** or newer, run commands with the environment variable
+  `NODE_OPTIONS=--openssl-legacy-provider` to avoid
+  `ERR_OSSL_EVP_UNSUPPORTED` build failures. This flag is already included in
+  the provided npm scripts.
 - [Angular CLI](https://angular.io/cli) **12.0.1** (`npm install -g @angular/cli@12`)
 
 ## Installation


### PR DESCRIPTION
## Summary
- add note about `NODE_OPTIONS=--openssl-legacy-provider` for Node 17+

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6841964081a88321bd7a508fd9332787