### PR TITLE
Fix profile service endpoint

### DIFF
--- a/src/app/services/dhan-api.service.ts
+++ b/src/app/services/dhan-api.service.ts
@@ -18,6 +18,6 @@ export class DhanApiService {
   constructor(private http: HttpClient) {}
 
   getUserProfile(): Observable<UserProfile> {
-    return this.http.get<UserProfile>(`${this.baseUrl}/TestDhan/profile`);
+    return this.http.get<UserProfile>(`${this.baseUrl}/profile`);
   }
 }


### PR DESCRIPTION
## Summary
- fix duplicate `/TestDhan` segment in profile API path

## Testing
- `npm test` *(fails: Disconnected Client disconnected from CONNECTED state)*

------
https://chatgpt.com/codex/tasks/task_e_68417d8d91308321b57f03f0dc14d20e