### PR TITLE
Add builder nav link

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -2,11 +2,13 @@ import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 import { ProfileComponent } from './profile/profile.component';
 import { DashboardComponent } from './dashboard/dashboard.component';
+import { StrategyBuilderComponent } from './strategy-builder/strategy-builder.component';
 
 const routes: Routes = [
   { path: '', redirectTo: 'profile', pathMatch: 'full' },
   { path: 'profile', component: ProfileComponent },
-  { path: 'dashboard', component: DashboardComponent }
+  { path: 'dashboard', component: DashboardComponent },
+  { path: 'builder', component: StrategyBuilderComponent }
 ];
 
 @NgModule({

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,6 +1,7 @@
 <mat-toolbar>
   <a mat-button routerLink="/profile">Profile</a>
   <a mat-button routerLink="/dashboard">Dashboard</a>
+  <a mat-button routerLink="/builder">Strategy Builder</a>
 </mat-toolbar>
 <div class="container mt-3">
   <router-outlet></router-outlet>

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -5,17 +5,23 @@ import { MatToolbarModule } from '@angular/material/toolbar';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
 import { MatTableModule } from '@angular/material/table';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatSelectModule } from '@angular/material/select';
+import { ReactiveFormsModule } from '@angular/forms';
 
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
 import { ProfileComponent } from './profile/profile.component';
 import { DashboardComponent } from './dashboard/dashboard.component';
+import { StrategyBuilderComponent } from './strategy-builder/strategy-builder.component';
 
 @NgModule({
   declarations: [
     AppComponent,
     ProfileComponent,
-    DashboardComponent
+    DashboardComponent,
+    StrategyBuilderComponent
   ],
   imports: [
     BrowserModule,
@@ -24,7 +30,11 @@ import { DashboardComponent } from './dashboard/dashboard.component';
     MatToolbarModule,
     MatButtonModule,
     MatCardModule,
-    MatTableModule
+    MatTableModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatSelectModule,
+    ReactiveFormsModule
   ],
   providers: [],
   bootstrap: [AppComponent]

--- a/src/app/services/strategy-builder.service.spec.ts
+++ b/src/app/services/strategy-builder.service.spec.ts
@@ -1,0 +1,46 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { StrategyBuilderService, StrategyLeg, OptionChainEntry } from './strategy-builder.service';
+import { environment } from '../../environments/environment';
+
+describe('StrategyBuilderService', () => {
+  let service: StrategyBuilderService;
+  let http: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule]
+    });
+    service = TestBed.inject(StrategyBuilderService);
+    http = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    http.verify();
+  });
+
+  it('should fetch option chain', () => {
+    const mockChain: OptionChainEntry[] = [
+      { strike: 100, callPrice: 1, putPrice: 2 }
+    ];
+    let response: OptionChainEntry[] | undefined;
+    service.getOptionChain('NIFTY').subscribe(res => (response = res));
+
+    const req = http.expectOne(`${environment.apiUrl}/options/NIFTY`);
+    expect(req.request.method).toBe('GET');
+    req.flush(mockChain);
+    expect(response).toEqual(mockChain);
+  });
+
+  it('should place multi-leg strategy', () => {
+    const legs: StrategyLeg[] = [
+      { symbol: 'NIFTY', action: 'BUY', quantity: 1, strike: 100, optionType: 'CE' }
+    ];
+    service.placeStrategy(legs).subscribe();
+
+    const req = http.expectOne(`${environment.apiUrl}/orders/multi-leg`);
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual({ legs });
+    req.flush({});
+  });
+});

--- a/src/app/services/strategy-builder.service.ts
+++ b/src/app/services/strategy-builder.service.ts
@@ -1,0 +1,43 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from '../../environments/environment';
+
+export interface OptionChainEntry {
+  strike: number;
+  callPrice: number;
+  putPrice: number;
+}
+
+export interface StrategyLeg {
+  symbol: string;
+  action: 'BUY' | 'SELL';
+  quantity: number;
+  strike: number;
+  optionType: 'CE' | 'PE';
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class StrategyBuilderService {
+  private baseUrl = environment.apiUrl;
+
+  constructor(private http: HttpClient) {}
+
+  getOptionChain(symbol: string): Observable<OptionChainEntry[]> {
+    return this.http.get<OptionChainEntry[]>(`${this.baseUrl}/options/${symbol}`);
+  }
+
+  placeOrder(order: StrategyLeg): Observable<void> {
+    return this.http.post<void>(`${this.baseUrl}/orders`, order);
+  }
+
+  placeStrategy(legs: StrategyLeg[]): Observable<void> {
+    return this.http.post<void>(`${this.baseUrl}/orders/multi-leg`, { legs });
+  }
+
+  cancelOrder(orderId: string): Observable<void> {
+    return this.http.delete<void>(`${this.baseUrl}/orders/${orderId}`);
+  }
+}

--- a/src/app/strategy-builder/strategy-builder.component.css
+++ b/src/app/strategy-builder/strategy-builder.component.css
@@ -1,0 +1,10 @@
+.full-width {
+  width: 100%;
+}
+
+.leg-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+}

--- a/src/app/strategy-builder/strategy-builder.component.html
+++ b/src/app/strategy-builder/strategy-builder.component.html
@@ -1,0 +1,61 @@
+<mat-card>
+  <form [formGroup]="form">
+    <mat-form-field appearance="fill" class="full-width">
+      <mat-label>Symbol</mat-label>
+      <input matInput formControlName="symbol" />
+    </mat-form-field>
+    <button mat-raised-button color="primary" (click)="loadChain()">Load Option Chain</button>
+  </form>
+</mat-card>
+
+<mat-card>
+  <form [formGroup]="form">
+  <div formArrayName="legs">
+    <div *ngFor="let leg of legs.controls; let i = index" [formGroupName]="i" class="leg-row">
+      <mat-form-field appearance="fill">
+        <mat-label>Action</mat-label>
+        <mat-select formControlName="action">
+          <mat-option value="BUY">Buy</mat-option>
+          <mat-option value="SELL">Sell</mat-option>
+        </mat-select>
+      </mat-form-field>
+      <mat-form-field appearance="fill">
+        <mat-label>Qty</mat-label>
+        <input matInput type="number" formControlName="quantity" />
+      </mat-form-field>
+      <mat-form-field appearance="fill">
+        <mat-label>Strike</mat-label>
+        <input matInput type="number" formControlName="strike" />
+      </mat-form-field>
+      <mat-form-field appearance="fill">
+        <mat-label>Type</mat-label>
+        <mat-select formControlName="optionType">
+          <mat-option value="CE">CE</mat-option>
+          <mat-option value="PE">PE</mat-option>
+        </mat-select>
+      </mat-form-field>
+    </div>
+  </div>
+  <button mat-button (click)="addLeg()">Add Leg</button>
+  <button mat-raised-button color="accent" (click)="submit()">Place Strategy</button>
+  </form>
+</mat-card>
+
+<mat-card *ngIf="optionChain$ | async as chain">
+  <table mat-table [dataSource]="chain" class="full-width">
+    <ng-container matColumnDef="strike">
+      <th mat-header-cell *matHeaderCellDef>Strike</th>
+      <td mat-cell *matCellDef="let row">{{ row.strike }}</td>
+    </ng-container>
+    <ng-container matColumnDef="callPrice">
+      <th mat-header-cell *matHeaderCellDef>Call</th>
+      <td mat-cell *matCellDef="let row">{{ row.callPrice }}</td>
+    </ng-container>
+    <ng-container matColumnDef="putPrice">
+      <th mat-header-cell *matHeaderCellDef>Put</th>
+      <td mat-cell *matCellDef="let row">{{ row.putPrice }}</td>
+    </ng-container>
+    <tr mat-header-row *matHeaderRowDef="['strike','callPrice','putPrice']"></tr>
+    <tr mat-row *matRowDef="let row; columns: ['strike','callPrice','putPrice']"></tr>
+  </table>
+</mat-card>

--- a/src/app/strategy-builder/strategy-builder.component.spec.ts
+++ b/src/app/strategy-builder/strategy-builder.component.spec.ts
@@ -1,0 +1,72 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ReactiveFormsModule } from '@angular/forms';
+import { of } from 'rxjs';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatSelectModule } from '@angular/material/select';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
+import { MatTableModule } from '@angular/material/table';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+import { StrategyBuilderComponent } from './strategy-builder.component';
+import { StrategyBuilderService, OptionChainEntry, StrategyLeg } from '../services/strategy-builder.service';
+
+describe('StrategyBuilderComponent', () => {
+  let component: StrategyBuilderComponent;
+  let fixture: ComponentFixture<StrategyBuilderComponent>;
+  let service: jasmine.SpyObj<StrategyBuilderService>;
+
+  beforeEach(async () => {
+    const spy = jasmine.createSpyObj('StrategyBuilderService', ['getOptionChain', 'placeStrategy']);
+
+    await TestBed.configureTestingModule({
+      imports: [
+        ReactiveFormsModule,
+        MatFormFieldModule,
+        MatInputModule,
+        MatSelectModule,
+        MatButtonModule,
+        MatCardModule,
+        MatTableModule,
+        NoopAnimationsModule
+      ],
+      declarations: [StrategyBuilderComponent],
+      providers: [{ provide: StrategyBuilderService, useValue: spy }]
+    }).compileComponents();
+
+    service = TestBed.inject(StrategyBuilderService) as jasmine.SpyObj<StrategyBuilderService>;
+  });
+
+  function createComponent() {
+    fixture = TestBed.createComponent(StrategyBuilderComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  }
+
+  it('should load option chain', () => {
+    const mock: OptionChainEntry[] = [{ strike: 100, callPrice: 1, putPrice: 2 }];
+    service.getOptionChain.and.returnValue(of(mock));
+    createComponent();
+
+    component.form.get('symbol')?.setValue('NIFTY');
+    component.loadChain();
+    fixture.detectChanges();
+
+    expect(service.getOptionChain).toHaveBeenCalledWith('NIFTY');
+  });
+
+  it('should send legs to service', () => {
+    service.placeStrategy.and.returnValue(of());
+    createComponent();
+    component.addLeg();
+    component.legs.at(0).patchValue({ quantity: 1, strike: 100 });
+    component.form.get('symbol')?.setValue('NIFTY');
+
+    component.submit();
+
+    const args = service.placeStrategy.calls.mostRecent().args[0];
+    expect(args.length).toBe(1);
+    expect(args[0]).toEqual(jasmine.objectContaining({ action: 'BUY', quantity: 1, strike: 100, optionType: 'CE' }));
+  });
+});

--- a/src/app/strategy-builder/strategy-builder.component.ts
+++ b/src/app/strategy-builder/strategy-builder.component.ts
@@ -1,0 +1,50 @@
+import { Component } from '@angular/core';
+import { FormArray, FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { StrategyBuilderService, StrategyLeg, OptionChainEntry } from '../services/strategy-builder.service';
+import { Observable } from 'rxjs';
+
+@Component({
+  selector: 'app-strategy-builder',
+  templateUrl: './strategy-builder.component.html',
+  styleUrls: ['./strategy-builder.component.css']
+})
+export class StrategyBuilderComponent {
+  optionChain$!: Observable<OptionChainEntry[]>;
+  form: FormGroup;
+
+  get legs(): FormArray {
+    return this.form.get('legs') as FormArray;
+  }
+
+  constructor(private fb: FormBuilder, private service: StrategyBuilderService) {
+    this.form = this.fb.group({
+      symbol: ['', Validators.required],
+      legs: this.fb.array([])
+    });
+  }
+
+  loadChain(): void {
+    const symbol = this.form.get('symbol')?.value;
+    if (symbol) {
+      this.optionChain$ = this.service.getOptionChain(symbol);
+    }
+  }
+
+  addLeg(): void {
+    this.legs.push(
+      this.fb.group({
+        action: ['BUY', Validators.required],
+        quantity: [1, [Validators.required, Validators.min(1)]],
+        strike: [0, Validators.required],
+        optionType: ['CE', Validators.required]
+      })
+    );
+  }
+
+  submit(): void {
+    if (this.form.valid) {
+      const legs = this.legs.value as StrategyLeg[];
+      this.service.placeStrategy(legs).subscribe();
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add navigation link to the strategy builder page

## Testing
- `npm test -- --watch=false`

------
https://chatgpt.com/codex/tasks/task_e_684297d2a0048321aa2fc682923cf132