### PR TITLE
Add orderbook component and service

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -3,12 +3,14 @@ import { RouterModule, Routes } from '@angular/router';
 import { ProfileComponent } from './profile/profile.component';
 import { DashboardComponent } from './dashboard/dashboard.component';
 import { StrategyBuilderComponent } from './strategy-builder/strategy-builder.component';
+import { OrderbookComponent } from './orderbook/orderbook.component';
 
 const routes: Routes = [
   { path: '', redirectTo: 'profile', pathMatch: 'full' },
   { path: 'profile', component: ProfileComponent },
   { path: 'dashboard', component: DashboardComponent },
-  { path: 'builder', component: StrategyBuilderComponent }
+  { path: 'builder', component: StrategyBuilderComponent },
+  { path: 'orders', component: OrderbookComponent }
 ];
 
 @NgModule({

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -15,13 +15,15 @@ import { AppComponent } from './app.component';
 import { ProfileComponent } from './profile/profile.component';
 import { DashboardComponent } from './dashboard/dashboard.component';
 import { StrategyBuilderComponent } from './strategy-builder/strategy-builder.component';
+import { OrderbookComponent } from './orderbook/orderbook.component';
 
 @NgModule({
   declarations: [
     AppComponent,
     ProfileComponent,
     DashboardComponent,
-    StrategyBuilderComponent
+    StrategyBuilderComponent,
+    OrderbookComponent
   ],
   imports: [
     BrowserModule,

--- a/src/app/orderbook/orderbook.component.css
+++ b/src/app/orderbook/orderbook.component.css
@@ -1,0 +1,3 @@
+.full-width {
+  width: 100%;
+}

--- a/src/app/orderbook/orderbook.component.html
+++ b/src/app/orderbook/orderbook.component.html
@@ -1,0 +1,47 @@
+<mat-card>
+  <h2>Open Orders</h2>
+  <table mat-table [dataSource]="(openOrders$ | async) ?? []" class="full-width">
+    <ng-container matColumnDef="symbol">
+      <th mat-header-cell *matHeaderCellDef>Symbol</th>
+      <td mat-cell *matCellDef="let order">{{ order.symbol }}</td>
+    </ng-container>
+    <ng-container matColumnDef="quantity">
+      <th mat-header-cell *matHeaderCellDef>Qty</th>
+      <td mat-cell *matCellDef="let order">{{ order.quantity }}</td>
+    </ng-container>
+    <ng-container matColumnDef="price">
+      <th mat-header-cell *matHeaderCellDef>Price</th>
+      <td mat-cell *matCellDef="let order">{{ order.price }}</td>
+    </ng-container>
+    <ng-container matColumnDef="status">
+      <th mat-header-cell *matHeaderCellDef>Status</th>
+      <td mat-cell *matCellDef="let order">{{ order.status }}</td>
+    </ng-container>
+    <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+    <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
+  </table>
+</mat-card>
+
+<mat-card>
+  <h2>Order History</h2>
+  <table mat-table [dataSource]="(history$ | async) ?? []" class="full-width">
+    <ng-container matColumnDef="symbol">
+      <th mat-header-cell *matHeaderCellDef>Symbol</th>
+      <td mat-cell *matCellDef="let order">{{ order.symbol }}</td>
+    </ng-container>
+    <ng-container matColumnDef="quantity">
+      <th mat-header-cell *matHeaderCellDef>Qty</th>
+      <td mat-cell *matCellDef="let order">{{ order.quantity }}</td>
+    </ng-container>
+    <ng-container matColumnDef="price">
+      <th mat-header-cell *matHeaderCellDef>Price</th>
+      <td mat-cell *matCellDef="let order">{{ order.price }}</td>
+    </ng-container>
+    <ng-container matColumnDef="status">
+      <th mat-header-cell *matHeaderCellDef>Status</th>
+      <td mat-cell *matCellDef="let order">{{ order.status }}</td>
+    </ng-container>
+    <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+    <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
+  </table>
+</mat-card>

--- a/src/app/orderbook/orderbook.component.spec.ts
+++ b/src/app/orderbook/orderbook.component.spec.ts
@@ -1,0 +1,47 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { of } from 'rxjs';
+import { MatCardModule } from '@angular/material/card';
+import { MatTableModule } from '@angular/material/table';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+import { OrderbookComponent } from './orderbook.component';
+import { OrderbookService, Order } from '../services/orderbook.service';
+
+describe('OrderbookComponent', () => {
+  let component: OrderbookComponent;
+  let fixture: ComponentFixture<OrderbookComponent>;
+  let service: jasmine.SpyObj<OrderbookService>;
+
+  beforeEach(async () => {
+    const spy = jasmine.createSpyObj('OrderbookService', ['getOpenOrders', 'getOrderHistory']);
+
+    await TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule, MatCardModule, MatTableModule, NoopAnimationsModule],
+      declarations: [OrderbookComponent],
+      providers: [{ provide: OrderbookService, useValue: spy }]
+    }).compileComponents();
+
+    service = TestBed.inject(OrderbookService) as jasmine.SpyObj<OrderbookService>;
+  });
+
+  function createComponent() {
+    fixture = TestBed.createComponent(OrderbookComponent);
+    component = fixture.componentInstance;
+  }
+
+  it('should display orders from the service', () => {
+    const open: Order[] = [{ id: '1', symbol: 'AAPL', quantity: 1, price: 1, status: 'OPEN' }];
+    const history: Order[] = [{ id: '2', symbol: 'AAPL', quantity: 1, price: 1, status: 'FILLED' }];
+    service.getOpenOrders.and.returnValue(of(open));
+    service.getOrderHistory.and.returnValue(of(history));
+
+    createComponent();
+    fixture.detectChanges();
+    fixture.detectChanges();
+
+    const compiled = fixture.nativeElement as HTMLElement;
+    const rows = compiled.querySelectorAll('tr.mat-row');
+    expect(rows.length).toBe(2);
+  });
+});

--- a/src/app/orderbook/orderbook.component.ts
+++ b/src/app/orderbook/orderbook.component.ts
@@ -1,0 +1,22 @@
+import { Component, OnInit } from '@angular/core';
+import { Observable } from 'rxjs';
+import { OrderbookService, Order } from '../services/orderbook.service';
+
+@Component({
+  selector: 'app-orderbook',
+  templateUrl: './orderbook.component.html',
+  styleUrls: ['./orderbook.component.css']
+})
+export class OrderbookComponent implements OnInit {
+  openOrders$!: Observable<Order[]>;
+  history$!: Observable<Order[]>;
+
+  displayedColumns = ['symbol', 'quantity', 'price', 'status'];
+
+  constructor(private service: OrderbookService) {}
+
+  ngOnInit(): void {
+    this.openOrders$ = this.service.getOpenOrders();
+    this.history$ = this.service.getOrderHistory();
+  }
+}

--- a/src/app/orderbook/orderbook.service.spec.ts
+++ b/src/app/orderbook/orderbook.service.spec.ts
@@ -1,0 +1,43 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { OrderbookService, Order } from '../services/orderbook.service';
+import { environment } from '../../environments/environment';
+
+describe('OrderbookService', () => {
+  let service: OrderbookService;
+  let http: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule]
+    });
+    service = TestBed.inject(OrderbookService);
+    http = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    http.verify();
+  });
+
+  it('should fetch open orders', () => {
+    const mockOrders: Order[] = [{ id: '1', symbol: 'AAPL', quantity: 1, price: 1, status: 'OPEN' }];
+    let response: Order[] | undefined;
+    service.getOpenOrders().subscribe(res => (response = res));
+
+    const req = http.expectOne(`${environment.apiUrl}/orders/open`);
+    expect(req.request.method).toBe('GET');
+    req.flush(mockOrders);
+    expect(response).toEqual(mockOrders);
+  });
+
+  it('should fetch order history', () => {
+    const mockOrders: Order[] = [{ id: '1', symbol: 'AAPL', quantity: 1, price: 1, status: 'FILLED' }];
+    let response: Order[] | undefined;
+    service.getOrderHistory().subscribe(res => (response = res));
+
+    const req = http.expectOne(`${environment.apiUrl}/orders/history`);
+    expect(req.request.method).toBe('GET');
+    req.flush(mockOrders);
+    expect(response).toEqual(mockOrders);
+  });
+});

--- a/src/app/services/orderbook.service.ts
+++ b/src/app/services/orderbook.service.ts
@@ -1,0 +1,29 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from '../../environments/environment';
+
+export interface Order {
+  id: string;
+  symbol: string;
+  quantity: number;
+  price: number;
+  status: string;
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class OrderbookService {
+  private baseUrl = environment.apiUrl;
+
+  constructor(private http: HttpClient) {}
+
+  getOpenOrders(): Observable<Order[]> {
+    return this.http.get<Order[]>(`${this.baseUrl}/orders/open`);
+  }
+
+  getOrderHistory(): Observable<Order[]> {
+    return this.http.get<Order[]>(`${this.baseUrl}/orders/history`);
+  }
+}


### PR DESCRIPTION
## Summary
- create orderbook service for open orders and history
- show orders in new Orderbook component
- register the component and add /orders route
- test service and component

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadlessNoSandbox`

------
https://chatgpt.com/codex/tasks/task_e_6842a17e066883218afb30154af3378a