### PR TITLE
Add leg removal and drag-drop to strategy builder

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -9,6 +9,8 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
+import { MatIconModule } from '@angular/material/icon';
+import { DragDropModule } from '@angular/cdk/drag-drop';
 import { ReactiveFormsModule } from '@angular/forms';
 
 import { AppRoutingModule } from './app-routing.module';
@@ -37,8 +39,10 @@ import { OrderbookComponent } from './orderbook/orderbook.component';
     MatFormFieldModule,
     MatInputModule,
     MatSelectModule,
+    MatIconModule,
     ReactiveFormsModule,
-    MatSnackBarModule
+    MatSnackBarModule,
+    DragDropModule
   ],
   providers: [],
   bootstrap: [AppComponent]

--- a/src/app/strategy-builder/strategy-builder.component.html
+++ b/src/app/strategy-builder/strategy-builder.component.html
@@ -10,8 +10,8 @@
 
 <mat-card>
   <form [formGroup]="form">
-  <div formArrayName="legs">
-    <div *ngFor="let leg of legs.controls; let i = index" [formGroupName]="i" class="leg-row">
+  <div formArrayName="legs" cdkDropList (cdkDropListDropped)="drop($event)">
+    <div *ngFor="let leg of legs.controls; let i = index" [formGroupName]="i" class="leg-row" cdkDrag>
       <mat-form-field appearance="fill">
         <mat-label>Action</mat-label>
         <mat-select formControlName="action">
@@ -34,6 +34,9 @@
           <mat-option value="PE">PE</mat-option>
         </mat-select>
       </mat-form-field>
+      <button mat-icon-button color="warn" type="button" (click)="removeLeg(i)" aria-label="Remove leg">
+        <mat-icon>delete</mat-icon>
+      </button>
     </div>
   </div>
   <button mat-button (click)="addLeg()">Add Leg</button>

--- a/src/app/strategy-builder/strategy-builder.component.spec.ts
+++ b/src/app/strategy-builder/strategy-builder.component.spec.ts
@@ -8,10 +8,13 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
 import { MatTableModule } from '@angular/material/table';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { DragDropModule } from '@angular/cdk/drag-drop';
+import { MatIconModule } from '@angular/material/icon';
 import { MatSnackBar } from '@angular/material/snack-bar';
 
 import { StrategyBuilderComponent } from './strategy-builder.component';
 import { StrategyBuilderService, OptionChainEntry, StrategyLeg } from '../services/strategy-builder.service';
+import { CdkDragDrop } from '@angular/cdk/drag-drop';
 
 describe('StrategyBuilderComponent', () => {
   let component: StrategyBuilderComponent;
@@ -32,7 +35,9 @@ describe('StrategyBuilderComponent', () => {
         MatButtonModule,
         MatCardModule,
         MatTableModule,
-        NoopAnimationsModule
+        NoopAnimationsModule,
+        DragDropModule,
+        MatIconModule
       ],
       declarations: [StrategyBuilderComponent],
       providers: [
@@ -75,6 +80,30 @@ describe('StrategyBuilderComponent', () => {
     const args = service.placeStrategy.calls.mostRecent().args[0];
     expect(args.length).toBe(1);
     expect(args[0]).toEqual(jasmine.objectContaining({ action: 'BUY', quantity: 1, strike: 100, optionType: 'CE' }));
+  });
+
+  it('should remove a leg', () => {
+    createComponent();
+    component.addLeg();
+    component.addLeg();
+
+    expect(component.legs.length).toBe(2);
+    component.removeLeg(0);
+    expect(component.legs.length).toBe(1);
+  });
+
+  it('should reorder legs on drop', () => {
+    createComponent();
+    component.addLeg();
+    component.addLeg();
+    component.legs.at(0).patchValue({ strike: 100 });
+    component.legs.at(1).patchValue({ strike: 200 });
+
+    const event = { previousIndex: 0, currentIndex: 1 } as CdkDragDrop<string[]>;
+    component.drop(event);
+
+    expect(component.legs.at(0).value.strike).toBe(200);
+    expect(component.legs.at(1).value.strike).toBe(100);
   });
 
   it('should show success message when strategy placed', fakeAsync(() => {

--- a/src/app/strategy-builder/strategy-builder.component.ts
+++ b/src/app/strategy-builder/strategy-builder.component.ts
@@ -1,5 +1,6 @@
 import { Component } from '@angular/core';
 import { FormArray, FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { CdkDragDrop } from '@angular/cdk/drag-drop';
 import { StrategyBuilderService, StrategyLeg, OptionChainEntry } from '../services/strategy-builder.service';
 import { Observable } from 'rxjs';
 import { MatSnackBar } from '@angular/material/snack-bar';
@@ -44,6 +45,16 @@ export class StrategyBuilderComponent {
         optionType: ['CE', Validators.required]
       })
     );
+  }
+
+  removeLeg(index: number): void {
+    this.legs.removeAt(index);
+  }
+
+  drop(event: CdkDragDrop<string[]>): void {
+    const prev = this.legs.at(event.previousIndex);
+    this.legs.removeAt(event.previousIndex);
+    this.legs.insert(event.currentIndex, prev);
   }
 
   submit(): void {


### PR DESCRIPTION
## Summary
- allow removing and reordering of legs in Strategy Builder
- integrate CDK Drag & Drop in component
- add MatIcon and DragDrop modules
- test leg removal and reordering

## Testing
- `npm test --silent -- --watch=false`

------
https://chatgpt.com/codex/tasks/task_e_6842a5950a7c83218b9b6da0d5f98fe0