### PR TITLE
Add OptionsChain component and service method

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -4,13 +4,15 @@ import { ProfileComponent } from './profile/profile.component';
 import { DashboardComponent } from './dashboard/dashboard.component';
 import { StrategyBuilderComponent } from './strategy-builder/strategy-builder.component';
 import { OrderbookComponent } from './orderbook/orderbook.component';
+import { OptionsChainComponent } from './options-chain/options-chain.component';
 
 const routes: Routes = [
   { path: '', redirectTo: 'profile', pathMatch: 'full' },
   { path: 'profile', component: ProfileComponent },
   { path: 'dashboard', component: DashboardComponent },
   { path: 'builder', component: StrategyBuilderComponent },
-  { path: 'orders', component: OrderbookComponent }
+  { path: 'orders', component: OrderbookComponent },
+  { path: 'options-chain', component: OptionsChainComponent }
 ];
 
 @NgModule({

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -19,6 +19,7 @@ import { ProfileComponent } from './profile/profile.component';
 import { DashboardComponent } from './dashboard/dashboard.component';
 import { StrategyBuilderComponent } from './strategy-builder/strategy-builder.component';
 import { OrderbookComponent } from './orderbook/orderbook.component';
+import { OptionsChainComponent } from './options-chain/options-chain.component';
 
 @NgModule({
   declarations: [
@@ -26,7 +27,8 @@ import { OrderbookComponent } from './orderbook/orderbook.component';
     ProfileComponent,
     DashboardComponent,
     StrategyBuilderComponent,
-    OrderbookComponent
+    OrderbookComponent,
+    OptionsChainComponent
   ],
   imports: [
     BrowserModule,

--- a/src/app/options-chain/options-chain.component.css
+++ b/src/app/options-chain/options-chain.component.css
@@ -1,0 +1,10 @@
+.full-width {
+  width: 100%;
+}
+
+.filters {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 1rem;
+}

--- a/src/app/options-chain/options-chain.component.html
+++ b/src/app/options-chain/options-chain.component.html
@@ -1,0 +1,52 @@
+<mat-card>
+  <form [formGroup]="form" class="filters">
+    <mat-form-field>
+      <mat-label>Symbol</mat-label>
+      <input matInput formControlName="symbol" />
+    </mat-form-field>
+    <mat-form-field>
+      <mat-label>Expiry</mat-label>
+      <mat-select formControlName="expiry">
+        <mat-option *ngFor="let exp of expiries" [value]="exp">{{ exp }}</mat-option>
+      </mat-select>
+    </mat-form-field>
+    <mat-form-field>
+      <mat-label>Min Strike</mat-label>
+      <input matInput type="number" formControlName="minStrike" />
+    </mat-form-field>
+    <mat-form-field>
+      <mat-label>Max Strike</mat-label>
+      <input matInput type="number" formControlName="maxStrike" />
+    </mat-form-field>
+    <button mat-raised-button color="primary" (click)="load()">Load</button>
+  </form>
+
+  <table mat-table [dataSource]="filtered((chain$ | async) ?? [])" class="full-width">
+    <ng-container matColumnDef="strike">
+      <th mat-header-cell *matHeaderCellDef>Strike</th>
+      <td mat-cell *matCellDef="let row">{{ row.strike }}</td>
+    </ng-container>
+    <ng-container matColumnDef="callLtp">
+      <th mat-header-cell *matHeaderCellDef>Call LTP</th>
+      <td mat-cell *matCellDef="let row">{{ row.callLtp }}</td>
+    </ng-container>
+    <ng-container matColumnDef="putLtp">
+      <th mat-header-cell *matHeaderCellDef>Put LTP</th>
+      <td mat-cell *matCellDef="let row">{{ row.putLtp }}</td>
+    </ng-container>
+    <ng-container matColumnDef="oi">
+      <th mat-header-cell *matHeaderCellDef>OI</th>
+      <td mat-cell *matCellDef="let row">{{ row.oi }}</td>
+    </ng-container>
+    <ng-container matColumnDef="iv">
+      <th mat-header-cell *matHeaderCellDef>IV</th>
+      <td mat-cell *matCellDef="let row">{{ row.iv }}</td>
+    </ng-container>
+    <ng-container matColumnDef="greeks">
+      <th mat-header-cell *matHeaderCellDef>Greeks</th>
+      <td mat-cell *matCellDef="let row">{{ row.greeks }}</td>
+    </ng-container>
+    <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+    <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
+  </table>
+</mat-card>

--- a/src/app/options-chain/options-chain.component.spec.ts
+++ b/src/app/options-chain/options-chain.component.spec.ts
@@ -1,0 +1,60 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ReactiveFormsModule } from '@angular/forms';
+import { of } from 'rxjs';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatSelectModule } from '@angular/material/select';
+import { MatCardModule } from '@angular/material/card';
+import { MatTableModule } from '@angular/material/table';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+import { OptionsChainComponent } from './options-chain.component';
+import { StrategyBuilderService, OptionsChainRow } from '../services/strategy-builder.service';
+
+describe('OptionsChainComponent', () => {
+  let component: OptionsChainComponent;
+  let fixture: ComponentFixture<OptionsChainComponent>;
+  let service: jasmine.SpyObj<StrategyBuilderService>;
+
+  beforeEach(async () => {
+    const spy = jasmine.createSpyObj('StrategyBuilderService', ['getOptionsChain']);
+
+    await TestBed.configureTestingModule({
+      imports: [
+        ReactiveFormsModule,
+        MatFormFieldModule,
+        MatInputModule,
+        MatSelectModule,
+        MatCardModule,
+        MatTableModule,
+        NoopAnimationsModule
+      ],
+      declarations: [OptionsChainComponent],
+      providers: [{ provide: StrategyBuilderService, useValue: spy }]
+    }).compileComponents();
+
+    service = TestBed.inject(StrategyBuilderService) as jasmine.SpyObj<StrategyBuilderService>;
+  });
+
+  function createComponent() {
+    fixture = TestBed.createComponent(OptionsChainComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  }
+
+  it('should load options chain data', () => {
+    const mock: OptionsChainRow[] = [
+      { strike: 100, callLtp: 1, putLtp: 2, oi: 1, iv: 10, greeks: '0' }
+    ];
+    service.getOptionsChain.and.returnValue(of(mock));
+    createComponent();
+
+    component.form.patchValue({ symbol: 'NIFTY', expiry: '2024-01-01' });
+    component.load();
+    fixture.detectChanges();
+
+    expect(service.getOptionsChain).toHaveBeenCalledWith('NIFTY', '2024-01-01');
+    const rows = fixture.nativeElement.querySelectorAll('tr.mat-row');
+    expect(rows.length).toBe(1);
+  });
+});

--- a/src/app/options-chain/options-chain.component.ts
+++ b/src/app/options-chain/options-chain.component.ts
@@ -1,0 +1,38 @@
+import { Component } from '@angular/core';
+import { FormBuilder, FormGroup } from '@angular/forms';
+import { Observable } from 'rxjs';
+import { StrategyBuilderService, OptionsChainRow } from '../services/strategy-builder.service';
+
+@Component({
+  selector: 'app-options-chain',
+  templateUrl: './options-chain.component.html',
+  styleUrls: ['./options-chain.component.css']
+})
+export class OptionsChainComponent {
+  chain$!: Observable<OptionsChainRow[]>;
+  form: FormGroup;
+  displayedColumns = ['strike', 'callLtp', 'putLtp', 'oi', 'iv', 'greeks'];
+  expiries = ['2024-01-01'];
+
+  constructor(private fb: FormBuilder, private service: StrategyBuilderService) {
+    this.form = this.fb.group({
+      symbol: [''],
+      expiry: [''],
+      minStrike: [],
+      maxStrike: []
+    });
+  }
+
+  load(): void {
+    const { symbol, expiry } = this.form.value;
+    if (symbol && expiry) {
+      this.chain$ = this.service.getOptionsChain(symbol, expiry);
+    }
+  }
+
+  filtered(data: OptionsChainRow[]): OptionsChainRow[] {
+    const min = this.form.get('minStrike')?.value;
+    const max = this.form.get('maxStrike')?.value;
+    return data.filter(d => (min ? d.strike >= min : true) && (max ? d.strike <= max : true));
+  }
+}

--- a/src/app/services/strategy-builder.service.spec.ts
+++ b/src/app/services/strategy-builder.service.spec.ts
@@ -1,6 +1,6 @@
 import { TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
-import { StrategyBuilderService, StrategyLeg, OptionChainEntry } from './strategy-builder.service';
+import { StrategyBuilderService, StrategyLeg, OptionChainEntry, OptionsChainRow } from './strategy-builder.service';
 import { environment } from '../../environments/environment';
 
 describe('StrategyBuilderService', () => {
@@ -30,6 +30,21 @@ describe('StrategyBuilderService', () => {
     expect(req.request.method).toBe('GET');
     req.flush(mockChain);
     expect(response).toEqual(mockChain);
+  });
+
+  it('should fetch options chain with expiry', () => {
+    const mock: OptionsChainRow[] = [
+      { strike: 100, callLtp: 1, putLtp: 2, oi: 1, iv: 10, greeks: '0' }
+    ];
+    let res: OptionsChainRow[] | undefined;
+    service.getOptionsChain('NIFTY', '2024-01-01').subscribe(v => (res = v));
+
+    const req = http.expectOne(
+      `${environment.apiUrl}/options/chain?symbol=NIFTY&expiry=2024-01-01`
+    );
+    expect(req.request.method).toBe('GET');
+    req.flush(mock);
+    expect(res).toEqual(mock);
   });
 
   it('should place multi-leg strategy', () => {

--- a/src/app/services/strategy-builder.service.ts
+++ b/src/app/services/strategy-builder.service.ts
@@ -9,6 +9,15 @@ export interface OptionChainEntry {
   putPrice: number;
 }
 
+export interface OptionsChainRow {
+  strike: number;
+  callLtp: number;
+  putLtp: number;
+  oi: number;
+  iv: number;
+  greeks: string;
+}
+
 export interface StrategyLeg {
   symbol: string;
   action: 'BUY' | 'SELL';
@@ -27,6 +36,10 @@ export class StrategyBuilderService {
 
   getOptionChain(symbol: string): Observable<OptionChainEntry[]> {
     return this.http.get<OptionChainEntry[]>(`${this.baseUrl}/options/${symbol}`);
+  }
+
+  getOptionsChain(symbol: string, expiry: string): Observable<OptionsChainRow[]> {
+    return this.http.get<OptionsChainRow[]>(`${this.baseUrl}/options/chain?symbol=${symbol}&expiry=${expiry}`);
   }
 
   placeOrder(order: StrategyLeg): Observable<void> {


### PR DESCRIPTION
## Summary
- extend `StrategyBuilderService` with `getOptionsChain`
- add `OptionsChainComponent` using Material table
- register component and routing
- add unit tests for service and component

## Testing
- `npm test` *(fails: Chrome cannot run as root with --no-sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_6842b3b59ee4832181788372f1903829