### PR TITLE
Add Alert Log feature

### DIFF
--- a/src/app/alert-log/alert-log.component.css
+++ b/src/app/alert-log/alert-log.component.css
@@ -1,0 +1,3 @@
+.full-width {
+  width: 100%;
+}

--- a/src/app/alert-log/alert-log.component.html
+++ b/src/app/alert-log/alert-log.component.html
@@ -1,0 +1,22 @@
+<mat-card>
+  <table mat-table [dataSource]="(alerts$ | async) ?? []" class="full-width">
+    <ng-container matColumnDef="time">
+      <th mat-header-cell *matHeaderCellDef>Time</th>
+      <td mat-cell *matCellDef="let alert">{{ alert.time }}</td>
+    </ng-container>
+    <ng-container matColumnDef="symbol">
+      <th mat-header-cell *matHeaderCellDef>Symbol</th>
+      <td mat-cell *matCellDef="let alert">{{ alert.symbol }}</td>
+    </ng-container>
+    <ng-container matColumnDef="action">
+      <th mat-header-cell *matHeaderCellDef>Action</th>
+      <td mat-cell *matCellDef="let alert">{{ alert.action }}</td>
+    </ng-container>
+    <ng-container matColumnDef="status">
+      <th mat-header-cell *matHeaderCellDef>Status</th>
+      <td mat-cell *matCellDef="let alert">{{ alert.status }}</td>
+    </ng-container>
+    <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+    <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
+  </table>
+</mat-card>

--- a/src/app/alert-log/alert-log.component.spec.ts
+++ b/src/app/alert-log/alert-log.component.spec.ts
@@ -1,0 +1,46 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { of } from 'rxjs';
+import { MatCardModule } from '@angular/material/card';
+import { MatTableModule } from '@angular/material/table';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+import { AlertLogComponent } from './alert-log.component';
+import { AlertLogService, AlertLogEntry } from '../services/alert-log.service';
+
+describe('AlertLogComponent', () => {
+  let component: AlertLogComponent;
+  let fixture: ComponentFixture<AlertLogComponent>;
+  let service: jasmine.SpyObj<AlertLogService>;
+
+  beforeEach(async () => {
+    const spy = jasmine.createSpyObj('AlertLogService', ['getRecentAlerts']);
+
+    await TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule, MatCardModule, MatTableModule, NoopAnimationsModule],
+      declarations: [AlertLogComponent],
+      providers: [{ provide: AlertLogService, useValue: spy }]
+    }).compileComponents();
+
+    service = TestBed.inject(AlertLogService) as jasmine.SpyObj<AlertLogService>;
+  });
+
+  function createComponent() {
+    fixture = TestBed.createComponent(AlertLogComponent);
+    component = fixture.componentInstance;
+  }
+
+  it('should display alerts from the service', () => {
+    const data: AlertLogEntry[] = [
+      { time: 't', symbol: 'AAPL', action: 'BUY', status: 'received' }
+    ];
+    service.getRecentAlerts.and.returnValue(of(data));
+
+    createComponent();
+    fixture.detectChanges();
+    fixture.detectChanges();
+
+    const rows = fixture.nativeElement.querySelectorAll('tr.mat-row');
+    expect(rows.length).toBe(1);
+  });
+});

--- a/src/app/alert-log/alert-log.component.ts
+++ b/src/app/alert-log/alert-log.component.ts
@@ -1,0 +1,22 @@
+import { Component, OnInit } from '@angular/core';
+import { Observable, timer } from 'rxjs';
+import { switchMap } from 'rxjs/operators';
+import { AlertLogService, AlertLogEntry } from '../services/alert-log.service';
+
+@Component({
+  selector: 'app-alert-log',
+  templateUrl: './alert-log.component.html',
+  styleUrls: ['./alert-log.component.css']
+})
+export class AlertLogComponent implements OnInit {
+  alerts$!: Observable<AlertLogEntry[]>;
+  displayedColumns = ['time', 'symbol', 'action', 'status'];
+
+  constructor(private service: AlertLogService) {}
+
+  ngOnInit(): void {
+    this.alerts$ = timer(0, 5000).pipe(
+      switchMap(() => this.service.getRecentAlerts())
+    );
+  }
+}

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -5,6 +5,7 @@ import { DashboardComponent } from './dashboard/dashboard.component';
 import { StrategyBuilderComponent } from './strategy-builder/strategy-builder.component';
 import { OrderbookComponent } from './orderbook/orderbook.component';
 import { OptionsChainComponent } from './options-chain/options-chain.component';
+import { AlertLogComponent } from './alert-log/alert-log.component';
 
 const routes: Routes = [
   { path: '', redirectTo: 'profile', pathMatch: 'full' },
@@ -12,7 +13,8 @@ const routes: Routes = [
   { path: 'dashboard', component: DashboardComponent },
   { path: 'builder', component: StrategyBuilderComponent },
   { path: 'orders', component: OrderbookComponent },
-  { path: 'options-chain', component: OptionsChainComponent }
+  { path: 'options-chain', component: OptionsChainComponent },
+  { path: 'alerts', component: AlertLogComponent }
 ];
 
 @NgModule({

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -2,6 +2,7 @@
   <a mat-button routerLink="/profile">Profile</a>
   <a mat-button routerLink="/dashboard">Dashboard</a>
   <a mat-button routerLink="/builder">Strategy Builder</a>
+  <a mat-button routerLink="/alerts">Alerts</a>
 </mat-toolbar>
 <div class="container mt-3">
   <router-outlet></router-outlet>

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -20,6 +20,7 @@ import { DashboardComponent } from './dashboard/dashboard.component';
 import { StrategyBuilderComponent } from './strategy-builder/strategy-builder.component';
 import { OrderbookComponent } from './orderbook/orderbook.component';
 import { OptionsChainComponent } from './options-chain/options-chain.component';
+import { AlertLogComponent } from './alert-log/alert-log.component';
 
 @NgModule({
   declarations: [
@@ -28,7 +29,8 @@ import { OptionsChainComponent } from './options-chain/options-chain.component';
     DashboardComponent,
     StrategyBuilderComponent,
     OrderbookComponent,
-    OptionsChainComponent
+    OptionsChainComponent,
+    AlertLogComponent
   ],
   imports: [
     BrowserModule,

--- a/src/app/services/alert-log.service.spec.ts
+++ b/src/app/services/alert-log.service.spec.ts
@@ -1,0 +1,34 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+
+import { AlertLogService, AlertLogEntry } from './alert-log.service';
+
+describe('AlertLogService', () => {
+  let service: AlertLogService;
+  let http: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule]
+    });
+    service = TestBed.inject(AlertLogService);
+    http = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    http.verify();
+  });
+
+  it('should fetch recent alerts', () => {
+    const mock: AlertLogEntry[] = [
+      { time: 't', symbol: 'AAPL', action: 'BUY', status: 'received' }
+    ];
+    let response: AlertLogEntry[] | undefined;
+    service.getRecentAlerts().subscribe(res => (response = res));
+
+    const req = http.expectOne('/api/alerts/recent');
+    expect(req.request.method).toBe('GET');
+    req.flush(mock);
+    expect(response).toEqual(mock);
+  });
+});

--- a/src/app/services/alert-log.service.ts
+++ b/src/app/services/alert-log.service.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+
+export interface AlertLogEntry {
+  time: string;
+  symbol: string;
+  action: string;
+  status: 'received' | 'processed' | 'failed';
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class AlertLogService {
+  constructor(private http: HttpClient) {}
+
+  getRecentAlerts(): Observable<AlertLogEntry[]> {
+    return this.http.get<AlertLogEntry[]>('/api/alerts/recent');
+  }
+}


### PR DESCRIPTION
## Summary
- create `AlertLogComponent` and template to display TradingView alerts
- implement `AlertLogService` with `/api/alerts/recent` endpoint
- wire up auto-refresh every five seconds
- register new route and toolbar link
- include unit test scaffolding for service and component

## Testing
- `npm test` *(fails: Some tests did a full page reload)*

------
https://chatgpt.com/codex/tasks/task_e_6842c87986848321a5f1c727295db79b