### PR TITLE
Add StrategyBuilder module with form, graph and submission

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -3,6 +3,7 @@ import { RouterModule, Routes } from '@angular/router';
 import { ProfileComponent } from './profile/profile.component';
 import { DashboardComponent } from './dashboard/dashboard.component';
 import { StrategyBuilderComponent } from './strategy-builder/strategy-builder.component';
+import { StrategyFormComponent } from './strategy/strategy-form/strategy-form.component';
 import { OrderbookComponent } from './orderbook/orderbook.component';
 import { OptionsChainComponent } from './options-chain/options-chain.component';
 import { AlertLogComponent } from './alert-log/alert-log.component';
@@ -12,6 +13,7 @@ const routes: Routes = [
   { path: 'profile', component: ProfileComponent },
   { path: 'dashboard', component: DashboardComponent },
   { path: 'builder', component: StrategyBuilderComponent },
+  { path: 'strategy', component: StrategyFormComponent },
   { path: 'orders', component: OrderbookComponent },
   { path: 'options-chain', component: OptionsChainComponent },
   { path: 'alerts', component: AlertLogComponent }

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -2,6 +2,7 @@
   <a mat-button routerLink="/profile">Profile</a>
   <a mat-button routerLink="/dashboard">Dashboard</a>
   <a mat-button routerLink="/builder">Strategy Builder</a>
+  <a mat-button routerLink="/strategy">Strategy Builder V2</a>
   <a mat-button routerLink="/alerts">Alerts</a>
 </mat-toolbar>
 <div class="container mt-3">

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -21,6 +21,7 @@ import { StrategyBuilderComponent } from './strategy-builder/strategy-builder.co
 import { OrderbookComponent } from './orderbook/orderbook.component';
 import { OptionsChainComponent } from './options-chain/options-chain.component';
 import { AlertLogComponent } from './alert-log/alert-log.component';
+import { StrategyBuilderModule } from './strategy/strategy-builder.module';
 
 @NgModule({
   declarations: [
@@ -46,7 +47,8 @@ import { AlertLogComponent } from './alert-log/alert-log.component';
     MatIconModule,
     ReactiveFormsModule,
     MatSnackBarModule,
-    DragDropModule
+    DragDropModule,
+    StrategyBuilderModule
   ],
   providers: [],
   bootstrap: [AppComponent]

--- a/src/app/strategy/payoff-graph/payoff-graph.component.css
+++ b/src/app/strategy/payoff-graph/payoff-graph.component.css
@@ -1,0 +1,9 @@
+.graph-placeholder {
+  height: 200px;
+  background-color: #eee;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-top: 16px;
+  font-style: italic;
+}

--- a/src/app/strategy/payoff-graph/payoff-graph.component.html
+++ b/src/app/strategy/payoff-graph/payoff-graph.component.html
@@ -1,0 +1,1 @@
+<div class="graph-placeholder">Payoff graph placeholder</div>

--- a/src/app/strategy/payoff-graph/payoff-graph.component.ts
+++ b/src/app/strategy/payoff-graph/payoff-graph.component.ts
@@ -1,0 +1,10 @@
+import { Component, Input } from '@angular/core';
+
+@Component({
+  selector: 'app-payoff-graph',
+  templateUrl: './payoff-graph.component.html',
+  styleUrls: ['./payoff-graph.component.css']
+})
+export class PayoffGraphComponent {
+  @Input() legs: any[] = [];
+}

--- a/src/app/strategy/strategy-builder.module.ts
+++ b/src/app/strategy/strategy-builder.module.ts
@@ -1,0 +1,30 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ReactiveFormsModule } from '@angular/forms';
+import { MatCardModule } from '@angular/material/card';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatSelectModule } from '@angular/material/select';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatSnackBarModule } from '@angular/material/snack-bar';
+
+import { StrategyFormComponent } from './strategy-form/strategy-form.component';
+import { PayoffGraphComponent } from './payoff-graph/payoff-graph.component';
+
+@NgModule({
+  declarations: [StrategyFormComponent, PayoffGraphComponent],
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    MatCardModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatSelectModule,
+    MatButtonModule,
+    MatIconModule,
+    MatSnackBarModule
+  ],
+  exports: [StrategyFormComponent]
+})
+export class StrategyBuilderModule {}

--- a/src/app/strategy/strategy-form/strategy-form.component.css
+++ b/src/app/strategy/strategy-form/strategy-form.component.css
@@ -1,0 +1,10 @@
+.leg-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.summary {
+  margin-top: 16px;
+}

--- a/src/app/strategy/strategy-form/strategy-form.component.html
+++ b/src/app/strategy/strategy-form/strategy-form.component.html
@@ -1,0 +1,47 @@
+<mat-card>
+  <form [formGroup]="form" (ngSubmit)="submit()">
+    <div formArrayName="legs">
+      <div *ngFor="let leg of legs.controls; let i = index" [formGroupName]="i" class="leg-row">
+        <mat-form-field appearance="fill">
+          <mat-label>Type</mat-label>
+          <mat-select formControlName="type">
+            <mat-option value="Call">Call</mat-option>
+            <mat-option value="Put">Put</mat-option>
+          </mat-select>
+        </mat-form-field>
+        <mat-form-field appearance="fill">
+          <mat-label>Side</mat-label>
+          <mat-select formControlName="side">
+            <mat-option value="BUY">Buy</mat-option>
+            <mat-option value="SELL">Sell</mat-option>
+          </mat-select>
+        </mat-form-field>
+        <mat-form-field appearance="fill">
+          <mat-label>Strike</mat-label>
+          <input matInput type="number" formControlName="strike" />
+        </mat-form-field>
+        <mat-form-field appearance="fill">
+          <mat-label>Expiry</mat-label>
+          <input matInput formControlName="expiry" />
+        </mat-form-field>
+        <mat-form-field appearance="fill">
+          <mat-label>Qty</mat-label>
+          <input matInput type="number" formControlName="qty" />
+        </mat-form-field>
+        <button mat-icon-button color="warn" type="button" (click)="removeLeg(i)">
+          <mat-icon>delete</mat-icon>
+        </button>
+      </div>
+    </div>
+    <button mat-button type="button" (click)="addLeg()">Add Leg</button>
+    <button mat-raised-button color="primary" type="submit">Submit</button>
+  </form>
+
+  <div class="summary">
+    <p>Margin Required: {{ summary.margin }}</p>
+    <p>Max Profit: {{ summary.maxProfit }}</p>
+    <p>Max Loss: {{ summary.maxLoss }}</p>
+  </div>
+
+  <app-payoff-graph [legs]="legs.value"></app-payoff-graph>
+</mat-card>

--- a/src/app/strategy/strategy-form/strategy-form.component.ts
+++ b/src/app/strategy/strategy-form/strategy-form.component.ts
@@ -1,0 +1,60 @@
+import { Component } from '@angular/core';
+import { FormBuilder, FormGroup, FormArray, Validators } from '@angular/forms';
+import { HttpClient } from '@angular/common/http';
+import { MatSnackBar } from '@angular/material/snack-bar';
+
+@Component({
+  selector: 'app-strategy-form',
+  templateUrl: './strategy-form.component.html',
+  styleUrls: ['./strategy-form.component.css']
+})
+export class StrategyFormComponent {
+  form: FormGroup;
+
+  constructor(private fb: FormBuilder, private http: HttpClient, private snackBar: MatSnackBar) {
+    this.form = this.fb.group({
+      legs: this.fb.array([])
+    });
+    this.addLeg();
+  }
+
+  get legs(): FormArray {
+    return this.form.get('legs') as FormArray;
+  }
+
+  addLeg(): void {
+    this.legs.push(
+      this.fb.group({
+        type: ['Call', Validators.required],
+        side: ['BUY', Validators.required],
+        strike: [0, Validators.required],
+        expiry: ['', Validators.required],
+        qty: [1, Validators.required]
+      })
+    );
+  }
+
+  removeLeg(index: number): void {
+    this.legs.removeAt(index);
+  }
+
+  get summary() {
+    const legs = this.legs.value as any[];
+    const margin = legs.reduce((sum, l) => sum + Math.abs(l.qty) * 100, 0);
+    return {
+      margin,
+      maxProfit: 'N/A',
+      maxLoss: 'N/A'
+    };
+  }
+
+  submit(): void {
+    if (this.form.valid) {
+      const legs = this.legs.value;
+      this.http.post('/api/strategy/execute', { legs }).subscribe({
+        next: () => this.snackBar.open('Strategy submitted', 'Close', { duration: 2000 }),
+        error: () => this.snackBar.open('Failed to submit', 'Close', { duration: 2000 })
+      });
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add StrategyBuilderModule and expose `/strategy` route
- provide StrategyFormComponent for configuring option legs
- show payoff graph placeholder with PayoffGraphComponent
- add snackbar feedback and icon support

## Testing
- `npm test` *(fails: Chrome disconnect, 1 failing test)*

------
https://chatgpt.com/codex/tasks/task_e_6842ccdb40dc8321bf4f87ba50c2ff2b