### PR TITLE
Update alert endpoints with apiUrl

### DIFF
--- a/src/app/alert-log/alert-log.component.spec.ts
+++ b/src/app/alert-log/alert-log.component.spec.ts
@@ -1,4 +1,4 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, fakeAsync, tick, discardPeriodicTasks } from '@angular/core/testing';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { of } from 'rxjs';
 import { MatCardModule } from '@angular/material/card';
@@ -30,7 +30,7 @@ describe('AlertLogComponent', () => {
     component = fixture.componentInstance;
   }
 
-  it('should display alerts from the service', () => {
+  it('should display alerts from the service', fakeAsync(() => {
     const data: AlertLogEntry[] = [
       { time: 't', symbol: 'AAPL', action: 'BUY', status: 'received' }
     ];
@@ -38,9 +38,13 @@ describe('AlertLogComponent', () => {
 
     createComponent();
     fixture.detectChanges();
+    tick(1);
+    fixture.detectChanges();
+    tick(1);
     fixture.detectChanges();
 
     const rows = fixture.nativeElement.querySelectorAll('tr.mat-row');
     expect(rows.length).toBe(1);
-  });
+    discardPeriodicTasks();
+  }));
 });

--- a/src/app/services/alert-log.service.spec.ts
+++ b/src/app/services/alert-log.service.spec.ts
@@ -2,6 +2,7 @@ import { TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 
 import { AlertLogService, AlertLogEntry } from './alert-log.service';
+import { environment } from '../../environments/environment';
 
 describe('AlertLogService', () => {
   let service: AlertLogService;
@@ -26,7 +27,7 @@ describe('AlertLogService', () => {
     let response: AlertLogEntry[] | undefined;
     service.getRecentAlerts().subscribe(res => (response = res));
 
-    const req = http.expectOne('/api/alerts/recent');
+    const req = http.expectOne(`${environment.apiUrl}/alerts/recent`);
     expect(req.request.method).toBe('GET');
     req.flush(mock);
     expect(response).toEqual(mock);

--- a/src/app/services/alert-log.service.ts
+++ b/src/app/services/alert-log.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
+import { environment } from '../../environments/environment';
 
 export interface AlertLogEntry {
   time: string;
@@ -13,9 +14,11 @@ export interface AlertLogEntry {
   providedIn: 'root'
 })
 export class AlertLogService {
+  private baseUrl = environment.apiUrl;
+
   constructor(private http: HttpClient) {}
 
   getRecentAlerts(): Observable<AlertLogEntry[]> {
-    return this.http.get<AlertLogEntry[]>('/api/alerts/recent');
+    return this.http.get<AlertLogEntry[]>(`${this.baseUrl}/alerts/recent`);
   }
 }

--- a/src/app/strategy/strategy-form/strategy-form.component.ts
+++ b/src/app/strategy/strategy-form/strategy-form.component.ts
@@ -1,6 +1,7 @@
 import { Component } from '@angular/core';
 import { FormBuilder, FormGroup, FormArray, Validators } from '@angular/forms';
 import { HttpClient } from '@angular/common/http';
+import { environment } from '../../../environments/environment';
 
 @Component({
   selector: 'app-strategy-form',
@@ -50,7 +51,9 @@ export class StrategyFormComponent {
   submit(): void {
     if (this.form.valid) {
       const legs = this.legs.value;
-      this.http.post('/api/strategy/execute', { legs }).subscribe();
+      this.http
+        .post(`${environment.apiUrl}/strategy/execute`, { legs })
+        .subscribe();
     }
   }
 }


### PR DESCRIPTION
## Summary
- prepend `environment.apiUrl` for recent alerts endpoint
- post strategy executions to `${environment.apiUrl}`
- fix alert log tests

## Testing
- `npm test -- --watch=false`

------
https://chatgpt.com/codex/tasks/task_e_6842d726cb708321a6bf737d6279cc83