### PR TITLE
Add websocket notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,13 @@ base URLs are defined in the Angular environment files:
 - **Development:** `https://localhost:7288/api/TestDhan`
 - **Production:** `http://localhost:5037/api/TestDhan`
 
-You can change these values in
-`src/environments/environment.ts` and
+Websocket URLs for real-time notifications are also defined in the environment
+files:
+
+- **Development WS:** `wss://localhost:7288/ws/notifications`
+- **Production WS:** `ws://localhost:5037/ws/notifications`
+
+You can change these values in `src/environments/environment.ts` and
 `src/environments/environment.prod.ts`.
 
 ## Prerequisites

--- a/src/app/dashboard/dashboard.component.ts
+++ b/src/app/dashboard/dashboard.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { Observable } from 'rxjs';
 import { TradingService, Position } from '../services/trading.service';
+import { NotificationService } from '../services/notification.service';
 
 @Component({
   selector: 'app-dashboard',
@@ -13,9 +14,18 @@ export class DashboardComponent implements OnInit {
 
   displayedColumns = ['symbol', 'quantity', 'entryPrice', 'currentPrice', 'mtm'];
 
-  constructor(private tradingService: TradingService) {}
+  constructor(
+    private tradingService: TradingService,
+    private notifications: NotificationService
+  ) {}
 
   ngOnInit(): void {
+    this.load();
+    this.notifications.connect();
+    this.notifications.messages$.subscribe(() => this.load());
+  }
+
+  private load(): void {
     this.pnl$ = this.tradingService.getCurrentPnl();
     this.positions$ = this.tradingService.getOpenPositions();
   }

--- a/src/app/services/notification.service.ts
+++ b/src/app/services/notification.service.ts
@@ -1,0 +1,33 @@
+import { Injectable } from '@angular/core';
+import { webSocket, WebSocketSubject } from 'rxjs/webSocket';
+import { Observable, Subject } from 'rxjs';
+import { environment } from '../../environments/environment';
+
+export interface NotificationMessage {
+  type: string;
+  data: any;
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class NotificationService {
+  private socket?: WebSocketSubject<NotificationMessage>;
+  private messagesSubject = new Subject<NotificationMessage>();
+  messages$ = this.messagesSubject.asObservable();
+
+  connect(): void {
+    if (!this.socket || this.socket.closed) {
+      this.socket = webSocket<NotificationMessage>(environment.wsUrl);
+      this.socket.subscribe({
+        next: msg => this.messagesSubject.next(msg),
+        error: err => console.error('WebSocket error', err)
+      });
+    }
+  }
+
+  disconnect(): void {
+    this.socket?.complete();
+    this.socket = undefined;
+  }
+}

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,4 +1,5 @@
 export const environment = {
   production: true,
-  apiUrl: 'http://localhost:5037/api/TestDhan'
+  apiUrl: 'http://localhost:5037/api/TestDhan',
+  wsUrl: 'ws://localhost:5037/ws/notifications'
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -4,7 +4,8 @@
 
 export const environment = {
   production: false,
-  apiUrl: 'https://localhost:7288/api/TestDhan'
+  apiUrl: 'https://localhost:7288/api/TestDhan',
+  wsUrl: 'wss://localhost:7288/ws/notifications'
 };
 
 /*


### PR DESCRIPTION
## Summary
- add websocket URLs in environment files
- describe websocket URLs in README
- add NotificationService using WebSocket
- refresh dashboard data when notifications arrive

## Testing
- `npm test` *(fails: Some tests disconnected)*

------
https://chatgpt.com/codex/tasks/task_e_6842dd6e536c8321a789e27ee2a80ce7