### PR TITLE
Add auth module with interceptor

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,14 @@ The API base URL for development is set in `src/environments/environment.ts`.
 For production builds it is defined in `src/environments/environment.prod.ts`.
 Update these files to point the application to a different backend.
 
+## Authentication
+
+An experimental authentication module is provided under `src/app/auth`. The
+`LoginComponent` posts credentials to `${environment.apiUrl}/auth/login` and
+stores the returned JWT token in `localStorage`. All outgoing HTTP requests
+automatically include this token via an `AuthInterceptor`, which also displays
+errors using Angular Material snack bars.
+
 ## Development server
 
 Run `npm start` (or `ng serve`) for a dev server. Navigate to `http://localhost:4200/`. The app will automatically reload if you change any of the source files.

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -7,6 +7,7 @@ import { StrategyFormComponent } from './strategy/strategy-form/strategy-form.co
 import { OrderbookComponent } from './orderbook/orderbook.component';
 import { OptionsChainComponent } from './options-chain/options-chain.component';
 import { AlertLogComponent } from './alert-log/alert-log.component';
+import { LoginComponent } from './auth/login.component';
 
 const routes: Routes = [
   { path: '', redirectTo: 'profile', pathMatch: 'full' },
@@ -16,7 +17,8 @@ const routes: Routes = [
   { path: 'strategy', component: StrategyFormComponent },
   { path: 'orders', component: OrderbookComponent },
   { path: 'options-chain', component: OptionsChainComponent },
-  { path: 'alerts', component: AlertLogComponent }
+  { path: 'alerts', component: AlertLogComponent },
+  { path: 'login', component: LoginComponent }
 ];
 
 @NgModule({

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,5 +1,6 @@
 import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { HttpClientModule } from '@angular/common/http';
 import { MatToolbarModule } from '@angular/material/toolbar';
 import { MatButtonModule } from '@angular/material/button';
@@ -12,6 +13,7 @@ import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { MatIconModule } from '@angular/material/icon';
 import { DragDropModule } from '@angular/cdk/drag-drop';
 import { ReactiveFormsModule } from '@angular/forms';
+import { AuthModule } from './auth/auth.module';
 
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
@@ -35,6 +37,7 @@ import { StrategyBuilderModule } from './strategy/strategy-builder.module';
   ],
   imports: [
     BrowserModule,
+    BrowserAnimationsModule,
     AppRoutingModule,
     HttpClientModule,
     MatToolbarModule,
@@ -48,6 +51,7 @@ import { StrategyBuilderModule } from './strategy/strategy-builder.module';
     ReactiveFormsModule,
     MatSnackBarModule,
     DragDropModule,
+    AuthModule,
     StrategyBuilderModule
   ],
   providers: [],

--- a/src/app/auth/auth.interceptor.ts
+++ b/src/app/auth/auth.interceptor.ts
@@ -1,0 +1,28 @@
+import { Injectable } from '@angular/core';
+import { HttpEvent, HttpHandler, HttpInterceptor, HttpRequest, HttpErrorResponse } from '@angular/common/http';
+import { Observable, throwError } from 'rxjs';
+import { catchError } from 'rxjs/operators';
+import { AuthService } from './auth.service';
+import { MatSnackBar } from '@angular/material/snack-bar';
+
+/**
+ * AuthInterceptor appends JWT token and handles HTTP errors globally.
+ */
+@Injectable()
+export class AuthInterceptor implements HttpInterceptor {
+  constructor(private auth: AuthService, private snackBar: MatSnackBar) {}
+
+  intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
+    const token = this.auth.getToken();
+    let request = req;
+    if (token) {
+      request = req.clone({ setHeaders: { Authorization: `Bearer ${token}` } });
+    }
+    return next.handle(request).pipe(
+      catchError((error: HttpErrorResponse) => {
+        this.snackBar.open(error.message, 'Close', { duration: 3000 });
+        return throwError(() => error);
+      })
+    );
+  }
+}

--- a/src/app/auth/auth.module.ts
+++ b/src/app/auth/auth.module.ts
@@ -1,0 +1,27 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { HTTP_INTERCEPTORS, HttpClientModule } from '@angular/common/http';
+import { ReactiveFormsModule } from '@angular/forms';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatButtonModule } from '@angular/material/button';
+import { MatSnackBarModule } from '@angular/material/snack-bar';
+import { LoginComponent } from './login.component';
+import { AuthInterceptor } from './auth.interceptor';
+
+@NgModule({
+  declarations: [LoginComponent],
+  imports: [
+    CommonModule,
+    HttpClientModule,
+    ReactiveFormsModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatButtonModule,
+    MatSnackBarModule
+  ],
+  providers: [
+    { provide: HTTP_INTERCEPTORS, useClass: AuthInterceptor, multi: true }
+  ]
+})
+export class AuthModule {}

--- a/src/app/auth/auth.service.spec.ts
+++ b/src/app/auth/auth.service.spec.ts
@@ -1,0 +1,30 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { AuthService } from './auth.service';
+import { environment } from '../../environments/environment';
+
+describe('AuthService', () => {
+  let service: AuthService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule]
+    });
+    service = TestBed.inject(AuthService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it('should store token on login', () => {
+    service.login('user', 'pass').subscribe();
+
+    const req = httpMock.expectOne(`${environment.apiUrl}/auth/login`);
+    req.flush({ token: 'abc' });
+
+    expect(localStorage.getItem('token')).toBe('abc');
+  });
+});

--- a/src/app/auth/auth.service.ts
+++ b/src/app/auth/auth.service.ts
@@ -1,0 +1,36 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { tap } from 'rxjs/operators';
+import { environment } from '../../environments/environment';
+
+interface LoginResponse {
+  token: string;
+}
+
+/**
+ * AuthService handles authentication-related API calls.
+ */
+@Injectable({ providedIn: 'root' })
+export class AuthService {
+  private baseUrl = environment.apiUrl;
+
+  constructor(private http: HttpClient) {}
+
+  /**
+   * Sends credentials to the backend and stores the received token.
+   * @param username user's name
+   * @param password user's password
+   */
+  login(username: string, password: string): Observable<LoginResponse> {
+    return this.http.post<LoginResponse>(`${this.baseUrl}/auth/login`, { username, password })
+      .pipe(tap((res: LoginResponse) => localStorage.setItem('token', res.token)));
+  }
+
+  /**
+   * Retrieves the stored JWT token.
+   */
+  getToken(): string | null {
+    return localStorage.getItem('token');
+  }
+}

--- a/src/app/auth/login.component.html
+++ b/src/app/auth/login.component.html
@@ -1,0 +1,11 @@
+<form [formGroup]="loginForm" (ngSubmit)="onSubmit()">
+  <mat-form-field appearance="fill">
+    <mat-label>Username</mat-label>
+    <input matInput formControlName="username" />
+  </mat-form-field>
+  <mat-form-field appearance="fill">
+    <mat-label>Password</mat-label>
+    <input matInput formControlName="password" type="password" />
+  </mat-form-field>
+  <button mat-raised-button color="primary" type="submit">Login</button>
+</form>

--- a/src/app/auth/login.component.ts
+++ b/src/app/auth/login.component.ts
@@ -1,0 +1,31 @@
+import { Component } from '@angular/core';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { AuthService } from './auth.service';
+
+/**
+ * LoginComponent provides a simple login form.
+ */
+@Component({
+  selector: 'app-login',
+  templateUrl: './login.component.html'
+})
+export class LoginComponent {
+  loginForm: FormGroup;
+
+  constructor(private fb: FormBuilder, private auth: AuthService) {
+    this.loginForm = this.fb.group({
+      username: ['', Validators.required],
+      password: ['', Validators.required]
+    });
+  }
+
+  /**
+   * Submits credentials to AuthService.
+   */
+  onSubmit(): void {
+    if (this.loginForm.valid) {
+      const { username, password } = this.loginForm.value;
+      this.auth.login(username, password).subscribe();
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- implement new AuthModule with LoginComponent
- add AuthService and AuthInterceptor for JWT support
- register AuthModule in AppModule and add login route
- document authentication module in README
- add basic unit test for AuthService
- enable BrowserAnimationsModule in AppModule

## Testing
- `npm test --silent` *(fails: Some tests did a full page reload and disconnected)*

------
https://chatgpt.com/codex/tasks/task_e_6842e39a0b3c8321945a6b8220def94a