### PR TITLE
Add analytics and risk modules with auth guard

### DIFF
--- a/.github/workflows/webpack.yml
+++ b/.github/workflows/webpack.yml
@@ -22,7 +22,8 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
 
-    - name: Build
+    - name: Build and Test
       run: |
-        npm install
+        npm install --legacy-peer-deps
         npm run build
+        npm test -- --watch=false --browsers=ChromeHeadless

--- a/README.md
+++ b/README.md
@@ -73,6 +73,16 @@ modules are available (they are imported in `AppModule` by default):
 - `MatTableModule`
 - `MatSnackBarModule`
 
+## Analytics and Risk Management
+
+Two additional modules provide performance charts and margin settings.
+
+- Navigate to `/analytics` to see a sample bar chart using **ngx-charts**.
+- Navigate to `/risk` to configure maximum risk percentage and margin.
+
+Both routes are protected by the `AuthGuard` and lazy loaded to improve
+initial load time.
+
 ## Code scaffolding
 
 Run `ng generate component component-name` to generate a new component. You can also use `ng generate directive|pipe|service|class|guard|interface|enum|module`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@angular/animations": "~12.0.1",
+        "@angular/cdk": "^12.2.13",
         "@angular/common": "~12.0.1",
         "@angular/compiler": "~12.0.1",
         "@angular/core": "~12.0.1",
@@ -18,6 +19,7 @@
         "@angular/platform-browser": "~12.0.1",
         "@angular/platform-browser-dynamic": "~12.0.1",
         "@angular/router": "~12.0.1",
+        "@swimlane/ngx-charts": "^20.1.0",
         "bootstrap": "^5.3.6",
         "rxjs": "~6.6.0",
         "tslib": "^2.1.0",
@@ -282,7 +284,6 @@
       "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-12.2.13.tgz",
       "integrity": "sha512-zSKRhECyFqhingIeyRInIyTvYErt4gWo+x5DQr0b7YLUbU8DZSwWnG4w76Ke2s4U8T7ry1jpJBHoX/e8YBpGMg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.2.0"
       },
@@ -2681,6 +2682,37 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@swimlane/ngx-charts": {
+      "version": "20.1.0",
+      "resolved": "https://registry.npmjs.org/@swimlane/ngx-charts/-/ngx-charts-20.1.0.tgz",
+      "integrity": "sha512-PY/X+eW+ZEvF3N1kuUVV5H3NHoFXlIWOvNnCKAs874yye//ttgfL/Qf9haHQpki5WIHQtpwn8xM1ylVEQT98bg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-shape": "^2.0.0",
+        "d3-array": "^2.9.1",
+        "d3-brush": "^2.1.0",
+        "d3-color": "^2.0.0",
+        "d3-format": "^2.0.0",
+        "d3-hierarchy": "^2.0.0",
+        "d3-interpolate": "^2.0.1",
+        "d3-scale": "^3.2.3",
+        "d3-selection": "^2.0.0",
+        "d3-shape": "^2.0.0",
+        "d3-time-format": "^3.0.0",
+        "d3-transition": "^2.0.0",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@angular/animations": ">=12.0.0",
+        "@angular/cdk": ">=12.0.0",
+        "@angular/common": ">=12.0.0",
+        "@angular/core": ">=12.0.0",
+        "@angular/forms": ">=12.0.0",
+        "@angular/platform-browser": ">=12.0.0",
+        "@angular/platform-browser-dynamic": ">=12.0.0",
+        "rxjs": "^6.5.3 || ^7.4.0"
+      }
+    },
     "node_modules/@tootallnate/once": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
@@ -2716,6 +2748,21 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-2.0.4.tgz",
+      "integrity": "sha512-jjZVLBjEX4q6xneKMmv62UocaFJFOTQSb/1aTzs3m3ICTOFoVaqGBHpNLm/4dVi0/FTltfBKgmOK1ECj3/gGjA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-2.1.7.tgz",
+      "integrity": "sha512-HedHlfGHdwzKqX9+PiQVXZrdmGlwo7naoefJP7kCNk4Y7qcpQt1tUaoRa6qn0kbTdlaIHGO7111qLtb/6J8uuw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "^2"
       }
     },
     "node_modules/@types/eslint": {
@@ -5572,6 +5619,151 @@
       "integrity": "sha512-GAj5FOq0Hd+RsCGVJxZuKaIDXDf3h6GQoNEjFgbLLI/trgtavwUbSnZ5pVfg27DVCaWjIohryS0JFwIJyT2cMg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/d3-array": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "internmap": "^1.0.0"
+      }
+    },
+    "node_modules/d3-brush": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-2.1.0.tgz",
+      "integrity": "sha512-cHLLAFatBATyIKqZOkk/mDHUbzne2B3ZwxkzMHvFTCZCmLaXDpZRihQSn8UNXTkGD/3lb/W2sQz0etAftmHMJQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-dispatch": "1 - 2",
+        "d3-drag": "2",
+        "d3-interpolate": "1 - 2",
+        "d3-selection": "2",
+        "d3-transition": "2"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-2.0.0.tgz",
+      "integrity": "sha512-SPXi0TSKPD4g9tw0NMZFnR95XVgUZiBH+uUTqQuDu1OsE2zomHU7ho0FISciaPvosimixwHFl3WHLGabv6dDgQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-dispatch": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-2.0.0.tgz",
+      "integrity": "sha512-S/m2VsXI7gAti2pBoLClFFTMOO1HTtT0j99AuXLoGFKO6deHDdnv6ZGTxSTTUTgO1zVcv82fCOtDjYK4EECmWA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-drag": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-2.0.0.tgz",
+      "integrity": "sha512-g9y9WbMnF5uqB9qKqwIIa/921RYWzlUDv9Jl1/yONQwxbOfszAWTCm8u7HOTgJgRDXiRZN56cHT9pd24dmXs8w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-dispatch": "1 - 2",
+        "d3-selection": "2"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-2.0.0.tgz",
+      "integrity": "sha512-68/n9JWarxXkOWMshcT5IcjbB+agblQUaIsbnXmrzejn2O82n3p2A9R2zEB9HIEFWKFwPAEDDN8gR0VdSAyyAQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-format": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-2.0.0.tgz",
+      "integrity": "sha512-Ab3S6XuE/Q+flY96HXT0jOXcM4EAClYFnRGY5zsjRGNy6qCYrQsMffs7cV5Q9xejb35zxW5hf/guKw34kvIKsA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-hierarchy": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-2.0.0.tgz",
+      "integrity": "sha512-SwIdqM3HxQX2214EG9GTjgmCc/mbSx4mQBn+DuEETubhOw6/U3fmnji4uCVrmzOydMHSO1nZle5gh6HB/wdOzw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-interpolate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-2.0.1.tgz",
+      "integrity": "sha512-c5UhwwTs/yybcmTpAVqwSFl6vrQ8JZJoT5F7xNFK9pymv5C0Ymcc9/LIJHtYIggg/yS9YHw8i8O8tgb9pupjeQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-color": "1 - 2"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-2.0.0.tgz",
+      "integrity": "sha512-ZwZQxKhBnv9yHaiWd6ZU4x5BtCQ7pXszEV9CU6kRgwIQVQGLMv1oiL4M+MK/n79sYzsj+gcgpPQSctJUsLN7fA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-scale": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-3.3.0.tgz",
+      "integrity": "sha512-1JGp44NQCt5d1g+Yy+GeOnZP7xHo0ii8zsQp6PGzd+C1/dl0KGsp9A7Mxwp+1D1o4unbTTxVdU/ZOIEBoeZPbQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-array": "^2.3.0",
+        "d3-format": "1 - 2",
+        "d3-interpolate": "1.2.0 - 2",
+        "d3-time": "^2.1.1",
+        "d3-time-format": "2 - 3"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-2.0.0.tgz",
+      "integrity": "sha512-XoGGqhLUN/W14NmaqcO/bb1nqjDAw5WtSYb2X8wiuQWvSZUsUVYsOSkOybUrNvcBjaywBdYPy03eXHMXjk9nZA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-shape": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-2.1.0.tgz",
+      "integrity": "sha512-PnjUqfM2PpskbSLTJvAzp2Wv4CZsnAgTfcVRTwW03QR3MkXF8Uo7B1y/lWkAsmbKwuecto++4NlsYcvYpXpTHA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-path": "1 - 2"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-2.1.1.tgz",
+      "integrity": "sha512-/eIQe/eR4kCQwq7yxi7z4c6qEXf2IYGcjoWB5OOQy4Tq9Uv39/947qlDcN2TLkiTzQWzvnsuYPB9TrWaNfipKQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-array": "2"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-3.0.0.tgz",
+      "integrity": "sha512-UXJh6EKsHBTjopVqZBhFysQcoXSv/5yLONZvkQ5Kk3qbwiUYkdX17Xa1PT6U1ZWXGGfB1ey5L8dKMlFq2DO0Ag==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-time": "1 - 2"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-2.0.0.tgz",
+      "integrity": "sha512-TO4VLh0/420Y/9dO3+f9abDEFYeCUr2WZRlxJvbp4HPTQcSylXNiL6yZa9FIUvV1yRiFufl1bszTCLDqv9PWNA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-transition": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-2.0.0.tgz",
+      "integrity": "sha512-42ltAGgJesfQE3u9LuuBHNbGrI/AJjNL2OAUdclE70UE6Vy239GCBEYD38uBPoLeNsOhFStGpPI0BAOV+HMxog==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-color": "1 - 2",
+        "d3-dispatch": "1 - 2",
+        "d3-ease": "1 - 2",
+        "d3-interpolate": "1 - 2",
+        "d3-timer": "1 - 2"
+      },
+      "peerDependencies": {
+        "d3-selection": "2"
+      }
     },
     "node_modules/dashdash": {
       "version": "1.14.1",
@@ -8439,6 +8631,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/internmap": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==",
+      "license": "ISC"
+    },
     "node_modules/ip": {
       "version": "1.1.9",
       "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.9.tgz",
@@ -8986,14 +9184,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/jasmine-core": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-5.7.1.tgz",
-      "integrity": "sha512-QnurrtpKsPoixxG2R3d1xP0St/2kcX5oTZyDyQJMY+Vzi/HUlu1kGm+2V8Tz+9lV991leB1l0xcsyz40s9xOOw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/jest-worker": {
       "version": "26.6.2",
@@ -11225,8 +11415,7 @@
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
       "integrity": "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==",
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/parse5-html-rewriting-stream": {
       "version": "6.0.1",
@@ -14015,22 +14204,6 @@
         "typescript": {
           "optional": true
         }
-      }
-    },
-    "node_modules/puppeteer/node_modules/typescript": {
-      "version": "5.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
-      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "node_modules/qjobs": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "private": true,
   "dependencies": {
     "@angular/animations": "~12.0.1",
+    "@angular/cdk": "^12.2.13",
     "@angular/common": "~12.0.1",
     "@angular/compiler": "~12.0.1",
     "@angular/core": "~12.0.1",
@@ -20,6 +21,7 @@
     "@angular/platform-browser": "~12.0.1",
     "@angular/platform-browser-dynamic": "~12.0.1",
     "@angular/router": "~12.0.1",
+    "@swimlane/ngx-charts": "^20.1.0",
     "bootstrap": "^5.3.6",
     "rxjs": "~6.6.0",
     "tslib": "^2.1.0",

--- a/src/app/analytics/analytics-routing.module.ts
+++ b/src/app/analytics/analytics-routing.module.ts
@@ -1,0 +1,9 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { AnalyticsComponent } from './analytics.component';
+import { AuthGuard } from '../auth/auth.guard';
+
+const routes: Routes = [{ path: '', component: AnalyticsComponent, canActivate: [AuthGuard] }];
+
+@NgModule({ imports: [RouterModule.forChild(routes)], exports: [RouterModule] })
+export class AnalyticsRoutingModule {}

--- a/src/app/analytics/analytics.component.html
+++ b/src/app/analytics/analytics.component.html
@@ -1,0 +1,1 @@
+<ngx-charts-bar-vertical [view]="view" [results]="data"></ngx-charts-bar-vertical>

--- a/src/app/analytics/analytics.component.ts
+++ b/src/app/analytics/analytics.component.ts
@@ -1,0 +1,17 @@
+import { Component } from '@angular/core';
+
+/**
+ * AnalyticsComponent displays a sample bar chart of strategy performance.
+ */
+@Component({
+  selector: 'app-analytics',
+  templateUrl: './analytics.component.html'
+})
+export class AnalyticsComponent {
+  view: [number, number] = [700, 300];
+  data = [
+    { name: 'Strategy A', value: 20 },
+    { name: 'Strategy B', value: 35 },
+    { name: 'Strategy C', value: 15 }
+  ];
+}

--- a/src/app/analytics/analytics.module.ts
+++ b/src/app/analytics/analytics.module.ts
@@ -1,0 +1,11 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { NgxChartsModule } from '@swimlane/ngx-charts';
+import { AnalyticsComponent } from './analytics.component';
+import { AnalyticsRoutingModule } from './analytics-routing.module';
+
+@NgModule({
+  declarations: [AnalyticsComponent],
+  imports: [CommonModule, NgxChartsModule, AnalyticsRoutingModule]
+})
+export class AnalyticsModule {}

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -1,10 +1,7 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 import { ProfileComponent } from './profile/profile.component';
-import { DashboardComponent } from './dashboard/dashboard.component';
-import { StrategyBuilderComponent } from './strategy-builder/strategy-builder.component';
 import { StrategyFormComponent } from './strategy/strategy-form/strategy-form.component';
-import { OrderbookComponent } from './orderbook/orderbook.component';
 import { OptionsChainComponent } from './options-chain/options-chain.component';
 import { AlertLogComponent } from './alert-log/alert-log.component';
 import { LoginComponent } from './auth/login.component';
@@ -12,10 +9,27 @@ import { LoginComponent } from './auth/login.component';
 const routes: Routes = [
   { path: '', redirectTo: 'profile', pathMatch: 'full' },
   { path: 'profile', component: ProfileComponent },
-  { path: 'dashboard', component: DashboardComponent },
-  { path: 'builder', component: StrategyBuilderComponent },
+  {
+    path: 'dashboard',
+    loadChildren: () => import('./dashboard/dashboard.module').then(m => m.DashboardModule)
+  },
+  {
+    path: 'builder',
+    loadChildren: () => import('./strategy-builder/strategy-builder.module').then(m => m.StrategyBuilderModule)
+  },
   { path: 'strategy', component: StrategyFormComponent },
-  { path: 'orders', component: OrderbookComponent },
+  {
+    path: 'orders',
+    loadChildren: () => import('./orderbook/orderbook.module').then(m => m.OrderbookModule)
+  },
+  {
+    path: 'analytics',
+    loadChildren: () => import('./analytics/analytics.module').then(m => m.AnalyticsModule)
+  },
+  {
+    path: 'risk',
+    loadChildren: () => import('./risk-management/risk-management.module').then(m => m.RiskManagementModule)
+  },
   { path: 'options-chain', component: OptionsChainComponent },
   { path: 'alerts', component: AlertLogComponent },
   { path: 'login', component: LoginComponent }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -4,23 +4,13 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { HttpClientModule } from '@angular/common/http';
 import { MatToolbarModule } from '@angular/material/toolbar';
 import { MatButtonModule } from '@angular/material/button';
-import { MatCardModule } from '@angular/material/card';
-import { MatTableModule } from '@angular/material/table';
-import { MatFormFieldModule } from '@angular/material/form-field';
-import { MatInputModule } from '@angular/material/input';
-import { MatSelectModule } from '@angular/material/select';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
-import { MatIconModule } from '@angular/material/icon';
-import { DragDropModule } from '@angular/cdk/drag-drop';
-import { ReactiveFormsModule } from '@angular/forms';
 import { AuthModule } from './auth/auth.module';
+import { SharedModule } from './shared/shared.module';
 
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
 import { ProfileComponent } from './profile/profile.component';
-import { DashboardComponent } from './dashboard/dashboard.component';
-import { StrategyBuilderComponent } from './strategy-builder/strategy-builder.component';
-import { OrderbookComponent } from './orderbook/orderbook.component';
 import { OptionsChainComponent } from './options-chain/options-chain.component';
 import { AlertLogComponent } from './alert-log/alert-log.component';
 import { StrategyBuilderModule } from './strategy/strategy-builder.module';
@@ -29,9 +19,6 @@ import { StrategyBuilderModule } from './strategy/strategy-builder.module';
   declarations: [
     AppComponent,
     ProfileComponent,
-    DashboardComponent,
-    StrategyBuilderComponent,
-    OrderbookComponent,
     OptionsChainComponent,
     AlertLogComponent
   ],
@@ -42,17 +29,11 @@ import { StrategyBuilderModule } from './strategy/strategy-builder.module';
     HttpClientModule,
     MatToolbarModule,
     MatButtonModule,
-    MatCardModule,
-    MatTableModule,
-    MatFormFieldModule,
-    MatInputModule,
-    MatSelectModule,
     MatIconModule,
-    ReactiveFormsModule,
     MatSnackBarModule,
-    DragDropModule,
     AuthModule,
-    StrategyBuilderModule
+    StrategyBuilderModule,
+    SharedModule
   ],
   providers: [],
   bootstrap: [AppComponent]

--- a/src/app/auth/auth.guard.spec.ts
+++ b/src/app/auth/auth.guard.spec.ts
@@ -1,0 +1,27 @@
+import { Router } from '@angular/router';
+import { AuthService } from './auth.service';
+import { AuthGuard } from './auth.guard';
+
+describe('AuthGuard', () => {
+  let guard: AuthGuard;
+  let auth: jasmine.SpyObj<AuthService>;
+  let router: jasmine.SpyObj<Router>;
+
+  beforeEach(() => {
+    auth = jasmine.createSpyObj('AuthService', ['getToken']);
+    router = jasmine.createSpyObj('Router', ['navigate']);
+    guard = new AuthGuard(auth, router as any);
+  });
+
+  it('should allow activation when token exists', () => {
+    auth.getToken.and.returnValue('abc');
+    expect(guard.canActivate()).toBeTrue();
+    expect(router.navigate).not.toHaveBeenCalled();
+  });
+
+  it('should redirect to login when no token', () => {
+    auth.getToken.and.returnValue(null);
+    expect(guard.canActivate()).toBeFalse();
+    expect(router.navigate).toHaveBeenCalledWith(['/login']);
+  });
+});

--- a/src/app/auth/auth.guard.ts
+++ b/src/app/auth/auth.guard.ts
@@ -1,0 +1,19 @@
+import { Injectable } from '@angular/core';
+import { CanActivate, Router } from '@angular/router';
+import { AuthService } from './auth.service';
+
+/**
+ * AuthGuard protects routes from unauthenticated access.
+ */
+@Injectable({ providedIn: 'root' })
+export class AuthGuard implements CanActivate {
+  constructor(private auth: AuthService, private router: Router) {}
+
+  canActivate(): boolean {
+    if (this.auth.getToken()) {
+      return true;
+    }
+    this.router.navigate(['/login']);
+    return false;
+  }
+}

--- a/src/app/auth/auth.interceptor.spec.ts
+++ b/src/app/auth/auth.interceptor.spec.ts
@@ -1,0 +1,39 @@
+import { HttpHandler, HttpRequest, HttpResponse, HttpErrorResponse } from '@angular/common/http';
+import { of, throwError } from 'rxjs';
+import { AuthInterceptor } from './auth.interceptor';
+import { AuthService } from './auth.service';
+import { MatSnackBar } from '@angular/material/snack-bar';
+
+describe('AuthInterceptor', () => {
+  let interceptor: AuthInterceptor;
+  let auth: jasmine.SpyObj<AuthService>;
+  let snack: jasmine.SpyObj<MatSnackBar>;
+
+  beforeEach(() => {
+    auth = jasmine.createSpyObj('AuthService', ['getToken']);
+    snack = jasmine.createSpyObj('MatSnackBar', ['open']);
+    interceptor = new AuthInterceptor(auth, snack);
+  });
+
+  it('should add Authorization header', (done) => {
+    auth.getToken.and.returnValue('token');
+    const req = new HttpRequest('GET', '/');
+    const next: HttpHandler = { handle: (r: HttpRequest<any>) => {
+      expect(r.headers.get('Authorization')).toBe('Bearer token');
+      return of(new HttpResponse({ status: 200 }));
+    }};
+    interceptor.intercept(req, next).subscribe(() => done());
+  });
+
+  it('should show error message', (done) => {
+    auth.getToken.and.returnValue(null);
+    const req = new HttpRequest('GET', '/');
+    const next: HttpHandler = { handle: () => throwError(() => new HttpErrorResponse({ status: 401, statusText: 'Unauthorized' })) };
+    interceptor.intercept(req, next).subscribe({
+      error: () => {
+        expect(snack.open).toHaveBeenCalled();
+        done();
+      }
+    });
+  });
+});

--- a/src/app/dashboard/dashboard-routing.module.ts
+++ b/src/app/dashboard/dashboard-routing.module.ts
@@ -1,0 +1,9 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { DashboardComponent } from './dashboard.component';
+import { AuthGuard } from '../auth/auth.guard';
+
+const routes: Routes = [{ path: '', component: DashboardComponent, canActivate: [AuthGuard] }];
+
+@NgModule({ imports: [RouterModule.forChild(routes)], exports: [RouterModule] })
+export class DashboardRoutingModule {}

--- a/src/app/dashboard/dashboard.module.ts
+++ b/src/app/dashboard/dashboard.module.ts
@@ -1,0 +1,13 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatCardModule } from '@angular/material/card';
+import { MatTableModule } from '@angular/material/table';
+import { DashboardComponent } from './dashboard.component';
+import { DashboardRoutingModule } from './dashboard-routing.module';
+import { SharedModule } from '../shared/shared.module';
+
+@NgModule({
+  declarations: [DashboardComponent],
+  imports: [CommonModule, MatCardModule, MatTableModule, SharedModule, DashboardRoutingModule]
+})
+export class DashboardModule {}

--- a/src/app/orderbook/orderbook-routing.module.ts
+++ b/src/app/orderbook/orderbook-routing.module.ts
@@ -1,0 +1,9 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { OrderbookComponent } from './orderbook.component';
+import { AuthGuard } from '../auth/auth.guard';
+
+const routes: Routes = [{ path: '', component: OrderbookComponent, canActivate: [AuthGuard] }];
+
+@NgModule({ imports: [RouterModule.forChild(routes)], exports: [RouterModule] })
+export class OrderbookRoutingModule {}

--- a/src/app/orderbook/orderbook.module.ts
+++ b/src/app/orderbook/orderbook.module.ts
@@ -1,0 +1,12 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatTableModule } from '@angular/material/table';
+import { MatCardModule } from '@angular/material/card';
+import { OrderbookComponent } from './orderbook.component';
+import { OrderbookRoutingModule } from './orderbook-routing.module';
+
+@NgModule({
+  declarations: [OrderbookComponent],
+  imports: [CommonModule, MatTableModule, MatCardModule, OrderbookRoutingModule]
+})
+export class OrderbookModule {}

--- a/src/app/risk-management/risk-management-routing.module.ts
+++ b/src/app/risk-management/risk-management-routing.module.ts
@@ -1,0 +1,9 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { RiskManagementComponent } from './risk-management.component';
+import { AuthGuard } from '../auth/auth.guard';
+
+const routes: Routes = [{ path: '', component: RiskManagementComponent, canActivate: [AuthGuard] }];
+
+@NgModule({ imports: [RouterModule.forChild(routes)], exports: [RouterModule] })
+export class RiskManagementRoutingModule {}

--- a/src/app/risk-management/risk-management.component.html
+++ b/src/app/risk-management/risk-management.component.html
@@ -1,0 +1,11 @@
+<form [formGroup]="form" (ngSubmit)="save()">
+  <mat-form-field>
+    <mat-label>Max Risk %</mat-label>
+    <input matInput formControlName="maxRisk" type="number">
+  </mat-form-field>
+  <mat-form-field>
+    <mat-label>Margin</mat-label>
+    <input matInput formControlName="margin" type="number">
+  </mat-form-field>
+  <button mat-raised-button color="primary" type="submit">Save</button>
+</form>

--- a/src/app/risk-management/risk-management.component.ts
+++ b/src/app/risk-management/risk-management.component.ts
@@ -1,0 +1,26 @@
+import { Component } from '@angular/core';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+
+/**
+ * RiskManagementComponent allows configuration of margin and risk settings.
+ */
+@Component({
+  selector: 'app-risk-management',
+  templateUrl: './risk-management.component.html'
+})
+export class RiskManagementComponent {
+  form: FormGroup;
+
+  constructor(private fb: FormBuilder) {
+    this.form = this.fb.group({
+      maxRisk: [5, [Validators.required, Validators.min(0)]],
+      margin: [100000, [Validators.required, Validators.min(0)]]
+    });
+  }
+
+  save(): void {
+    if (this.form.valid) {
+      console.log('Risk settings saved', this.form.value);
+    }
+  }
+}

--- a/src/app/risk-management/risk-management.module.ts
+++ b/src/app/risk-management/risk-management.module.ts
@@ -1,0 +1,21 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ReactiveFormsModule } from '@angular/forms';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatButtonModule } from '@angular/material/button';
+import { RiskManagementComponent } from './risk-management.component';
+import { RiskManagementRoutingModule } from './risk-management-routing.module';
+
+@NgModule({
+  declarations: [RiskManagementComponent],
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatButtonModule,
+    RiskManagementRoutingModule
+  ]
+})
+export class RiskManagementModule {}

--- a/src/app/services/notification.service.spec.ts
+++ b/src/app/services/notification.service.spec.ts
@@ -1,0 +1,32 @@
+import { TestBed } from '@angular/core/testing';
+import { NotificationService, NotificationMessage } from './notification.service';
+import * as rxjsWebSocket from 'rxjs/webSocket';
+import { Subject } from 'rxjs';
+
+describe('NotificationService', () => {
+  let service: NotificationService;
+  let socket$: Subject<NotificationMessage>;
+
+  beforeEach(() => {
+    socket$ = new Subject<NotificationMessage>();
+    spyOn(rxjsWebSocket, 'webSocket').and.returnValue(socket$ as any);
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(NotificationService);
+  });
+
+  it('should emit messages from websocket', (done) => {
+    service.connect();
+    service.messages$.subscribe(msg => {
+      expect(msg.type).toBe('test');
+      done();
+    });
+    socket$.next({ type: 'test', data: 1 });
+  });
+
+  it('should close socket on disconnect', () => {
+    service.connect();
+    const completeSpy = spyOn(socket$, 'complete').and.callThrough();
+    service.disconnect();
+    expect(completeSpy).toHaveBeenCalled();
+  });
+});

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -1,0 +1,11 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { TableComponent } from './table/table.component';
+import { MatTableModule } from '@angular/material/table';
+
+@NgModule({
+  declarations: [TableComponent],
+  imports: [CommonModule, MatTableModule],
+  exports: [TableComponent]
+})
+export class SharedModule {}

--- a/src/app/shared/table/table.component.html
+++ b/src/app/shared/table/table.component.html
@@ -1,0 +1,8 @@
+<table mat-table [dataSource]="data" class="mat-elevation-z8 full-width">
+  <ng-container [matColumnDef]="col" *ngFor="let col of columns">
+    <th mat-header-cell *matHeaderCellDef>{{ col }}</th>
+    <td mat-cell *matCellDef="let row">{{ row[col] }}</td>
+  </ng-container>
+  <tr mat-header-row *matHeaderRowDef="columns"></tr>
+  <tr mat-row *matRowDef="let row; columns: columns;"></tr>
+</table>

--- a/src/app/shared/table/table.component.ts
+++ b/src/app/shared/table/table.component.ts
@@ -1,0 +1,13 @@
+import { Component, Input } from '@angular/core';
+
+/**
+ * TableComponent is a reusable wrapper around Angular Material tables.
+ */
+@Component({
+  selector: 'app-table',
+  templateUrl: './table.component.html'
+})
+export class TableComponent {
+  @Input() columns: string[] = [];
+  @Input() data: any[] = [];
+}

--- a/src/app/strategy-builder/strategy-builder-routing.module.ts
+++ b/src/app/strategy-builder/strategy-builder-routing.module.ts
@@ -1,0 +1,9 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { StrategyBuilderComponent } from './strategy-builder.component';
+import { AuthGuard } from '../auth/auth.guard';
+
+const routes: Routes = [{ path: '', component: StrategyBuilderComponent, canActivate: [AuthGuard] }];
+
+@NgModule({ imports: [RouterModule.forChild(routes)], exports: [RouterModule] })
+export class StrategyBuilderRoutingModule {}

--- a/src/app/strategy-builder/strategy-builder.module.ts
+++ b/src/app/strategy-builder/strategy-builder.module.ts
@@ -1,0 +1,29 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ReactiveFormsModule } from '@angular/forms';
+import { MatCardModule } from '@angular/material/card';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatSelectModule } from '@angular/material/select';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { DragDropModule } from '@angular/cdk/drag-drop';
+import { StrategyBuilderComponent } from './strategy-builder.component';
+import { StrategyBuilderRoutingModule } from './strategy-builder-routing.module';
+
+@NgModule({
+  declarations: [StrategyBuilderComponent],
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    MatCardModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatSelectModule,
+    MatButtonModule,
+    MatIconModule,
+    DragDropModule,
+    StrategyBuilderRoutingModule
+  ]
+})
+export class StrategyBuilderModule {}


### PR DESCRIPTION
## Summary
- add analytics and risk-management feature modules
- introduce shared module and reusable table component
- implement lazy loading for dashboard, builder, orders, analytics and risk routes
- provide AuthGuard with unit tests and interceptor/notification tests
- update CI workflow to run tests
- document new modules in README

## Testing
- `npm test --silent -- --watch=false --browsers=ChromeHeadlessNoSandbox` *(fails: Running as root without --no-sandbox is not supported)*

------
https://chatgpt.com/codex/tasks/task_e_6842ef54b6348321b23627e69f12594a