### PR TITLE
Fix material imports and profile template

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -5,6 +5,13 @@ import { HttpClientModule } from '@angular/common/http';
 import { MatToolbarModule } from '@angular/material/toolbar';
 import { MatButtonModule } from '@angular/material/button';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
+import { MatIconModule } from '@angular/material/icon';
+import { MatCardModule } from '@angular/material/card';
+import { MatTableModule } from '@angular/material/table';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatSelectModule } from '@angular/material/select';
+import { ReactiveFormsModule } from '@angular/forms';
 import { AuthModule } from './auth/auth.module';
 import { SharedModule } from './shared/shared.module';
 
@@ -31,6 +38,12 @@ import { StrategyBuilderModule } from './strategy/strategy-builder.module';
     MatButtonModule,
     MatIconModule,
     MatSnackBarModule,
+    MatCardModule,
+    MatTableModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatSelectModule,
+    ReactiveFormsModule,
     AuthModule,
     StrategyBuilderModule,
     SharedModule

--- a/src/app/profile/profile.component.html
+++ b/src/app/profile/profile.component.html
@@ -1,16 +1,16 @@
 <mat-card class="profile-card">
-  <div *ngIf="profile">
+  <div *ngIf="profile as p">
     <div class="field">
-      <span class="label">Dhan Client ID:</span>{{ profile.dhanClientId }}
+      <span class="label">Dhan Client ID:</span>{{ p.dhanClientId }}
     </div>
     <div class="field">
-      <span class="label">Token Validity:</span>{{ profile.tokenValidity }}
+      <span class="label">Token Validity:</span>{{ p.tokenValidity }}
     </div>
     <div class="field">
-      <span class="label">Active Segment:</span>{{ profile.activeSegment }}
+      <span class="label">Active Segment:</span>{{ p.activeSegment }}
     </div>
-    <div class="field"><span class="label">DDPI:</span>{{ profile.ddpi }}</div>
-    <div class="field"><span class="label">Data Plan:</span>{{ profile.dataPlan }}</div>
+    <div class="field"><span class="label">DDPI:</span>{{ p.ddpi }}</div>
+    <div class="field"><span class="label">Data Plan:</span>{{ p.dataPlan }}</div>
   </div>
   <div *ngIf="errorMessage" class="error-message">{{ errorMessage }}</div>
 </mat-card>


### PR DESCRIPTION
## Summary
- add missing Angular Material and forms modules to `AppModule`
- avoid undefined profile errors with alias in template

## Testing
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843ddc78fcc8321af76680a443e5d56